### PR TITLE
Produce a more helpful message for unpushed commits

### DIFF
--- a/bin/git-safe-to-checkout
+++ b/bin/git-safe-to-checkout
@@ -62,7 +62,12 @@ test -z "$UNTRACKED_FILES" || die "Error: There are untracked (and unignored fil
 BRANCH=$(git branch -r --contains HEAD)
 if [ -z "$BRANCH" ]
 then
-    die "Error: Changes have been made in the deployed repository (in `pwd`) that are not in the blessed repository"
+    echo "Error: Switching to a new commit in `pwd`"
+    echo "would risk losing the following commits that haven't been pushed to a remote:"
+    echo
+    git log HEAD --not --remotes --oneline
+    echo
+    die "You should resolve this manually."
 fi
 
 # Go through each submodule, from:


### PR DESCRIPTION
git-safe-to-checkout produces an error if HEAD isn't contained
in any remote branch, but the phrasing of this error message
(using DVCS jargon like "blessed repository") was confusing to
people.  This commit changes the message to list the commits
that might be lost and hopefully has a clearer message - it
should now look like:

```
Error: Switching to a new commit in /home/mark/whatever
would risk losing the following commits that haven't been pushed to a remote:

8f1fdcd Losable commit

git-safe-to-checkout: You should resolve this manually.
```
