### PR TITLE
Only use timestamped dir for $vcspath_install when deploying

### DIFF
--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -111,7 +111,7 @@ die "'$hostname' is not a vhost for '$vhost'" if (!grep { m/^$hostname$/ } @{$co
 
 my $vcspath_install = $vcspath;
 my $timestamp = gmtime->strftime('%Y-%m-%dT%H-%M-%S');
-if ($timestamped_deploy) {
+if ($timestamped_deploy && $action eq "deploy") {
     $vcspath_install = "$vcspath-$timestamp";
 }
 


### PR DESCRIPTION
Otherwise, treat a timestamped deploy as a non-timestamped deploy.
The $vcspath is the one that should be used in all other cases.

Fixes #5.