### PR TITLE
Fix timeouts in run-with-lockfile so that errant commands are definit…

### DIFF
--- a/run-with-lockfile/run-with-lockfile.c
+++ b/run-with-lockfile/run-with-lockfile.c
@@ -121,7 +121,7 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    if (argc - optind < 2) {
+    if ((call_exec && argc - optind < 2) || (!call_exec && argc - optind != 2)) {
         fprintf(stderr, "run-with-lockfile: incorrect arguments\n");
         usage(stderr);
         return 101;


### PR DESCRIPTION
…ely killed

run-with-lockfile couldn't effectively kill timed-out processes because it always
got a shell to start them -- all that was being killed was the spawning shell.
Now we have an option '-e' which makes run-with-lockfile exec() the command directly.
Also added a further timeout in case a TERM isn't enough; after 10 seconds a KILL is sent.