### PR TITLE
Updates to git update hook

### DIFF
--- a/bin/git-update-hook
+++ b/bin/git-update-hook
@@ -18,6 +18,10 @@ if [[ "$2" != $NULL_SHA1 ]]; then
     branch=$(git rev-parse --symbolic --abbrev-ref $1)
 fi
 
+if [[ "`git config --get mysociety.jslint`" != 'true' ]]; then
+   exit 0
+fi
+
 if [[ "$branch" == *gh-pages* ]]
 then
     exit 0

--- a/bin/git-update-hook
+++ b/bin/git-update-hook
@@ -11,9 +11,21 @@ MAGENTA="\033[35m"
 CYAN="\033[36m"
 WHITE="\033[37m"
 
-branch=$(git rev-parse --symbolic --abbrev-ref $1)
+NULL_SHA1="0000000000000000000000000000000000000000"
+
+branch="$1"
+if [[ "$2" != $NULL_SHA1 ]]; then
+    branch=$(git rev-parse --symbolic --abbrev-ref $1)
+fi
+
 if [[ "$branch" == *gh-pages* ]]
 then
+    exit 0
+fi
+
+if [ -n "$(git branch -a --contains "$3")" ]
+then
+    echo "$3 is already pointed to by another branch, assuming it's already been checked"
     exit 0
 fi
 
@@ -22,7 +34,11 @@ tmp=$(mktemp /tmp/git.update.XXXXXX)
 log=$(mktemp /tmp/git.update.log.XXXXXX)
 tree=$(mktemp /tmp/git.diff-tree.XXXXXX)
 
-git diff-tree -r "$2" "$3" > $tree
+FROM="$2"
+if [[ "$2" == $NULL_SHA1 ]]; then
+    FROM=$(git rev-parse $(git rev-list --reverse "$3" --not --branches|head -1)^)
+fi
+git diff-tree -r "$FROM" "$3" > $tree
 
 exit_status=0
 
@@ -31,7 +47,7 @@ do
   # skip lines showing parent commit
   test -z "$new_sha1" && continue
   # skip deletions
-  [ "$new_sha1" = "0000000000000000000000000000000000000000" ] && continue
+  [ "$new_sha1" = $NULL_SHA1 ] && continue
   # skip Modernizr and the like
   [[ $name =~ modernizr|OpenLayers|cordova|fancybox|placeholder|json2|geo.min|jquery|backbone|lodash|underscore|moment|bootstrap|select2|warwickshire/gamma ]] && continue
   # Only test .js files

--- a/bin/git-update-hook
+++ b/bin/git-update-hook
@@ -18,6 +18,19 @@ if [[ "$2" != $NULL_SHA1 ]]; then
     branch=$(git rev-parse --symbolic --abbrev-ref $1)
 fi
 
+if [[ "$branch" == "gh-pages" || "$branch" == "master" ]]; then
+  log=$(mktemp /tmp/git.update.log.XXXXXX)
+  if git log --oneline "$2".."$3" | grep -i '^[^ ]* \([^a-z]*WIP\|fixup\|squash\)' > $log; then
+    echo
+    echo -e "${RED}Bad commits found:${NOBOLD}" >&2
+    echo -e "${CYAN}$(cat $log)${NOBOLD}" >&2
+    echo
+    rm -f $log
+    exit 1
+  fi
+  rm -f $log
+fi
+
 if [[ "`git config --get mysociety.jslint`" != 'true' ]]; then
    exit 0
 fi


### PR DESCRIPTION
Main feature is to not allow fixup/squash/WIP commits to master/gh-pages branch.
Also only does JS lint checking if a local config variable is set (as this hook is now used on all repos).
And should cope better with new branch pushes and not give out warnings.