### PR TITLE
Add restore_time option to backup retrieval script

### DIFF
--- a/bin/retrieve_from_backup
+++ b/bin/retrieve_from_backup
@@ -22,10 +22,12 @@ my $gpg_passphrase = read_file($gpg_passphrase_file)
 
 my $source_url;
 my $target_directory;
+my $restore_time;
 
 GetOptions(
     "source_url=s"       => \$source_url,
     "target_directory=s" => \$target_directory,
+    "restore_time=s"     => \$restore_time,
 );
 
 die "Usage: $0 --source_url ... --target_directory ...\n"
@@ -35,6 +37,6 @@ die "Usage: $0 --source_url ... --target_directory ...\n"
 $options->{'gpg_passphrase'}   = $gpg_passphrase;
 $options->{'target_directory'} = $target_directory;
 $options->{'source_url'}       = $source_url;
+$options->{'restore_time'}     = $restore_time if defined $restore_time;
 
 duplicity_retrieve( $options, );
-


### PR DESCRIPTION
Simple change to `retrieve_from_backup` to permit the inclusion of a `restore_time` option that will just be passed through to `duplicity_retrieve` in `DuplicityBackups.pl`. An amendment to this has been made in the internal puppet repository.