### PR TITLE
Escape left-braces in deploy-vhost regex

### DIFF
--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -604,7 +604,7 @@ sub stop_site {
             open(FHIN, "$servers_dir/vhosts/downs/default.html")
                 or die "Failed to open $servers_dir/vhosts/downs/default.html for reading: $!\n";
             while (<FHIN>) {
-                s/{{site}}/$conf->{server_name}/;
+                s/\{\{site}}/$conf->{server_name}/;
                 print FHOUT;
             }
             close FHIN;


### PR DESCRIPTION
Simple change to prevent deprecation warnings in Perl 5.24.1.