### PR TITLE
Add wrapper for Google address lookups

### DIFF
--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -971,7 +971,7 @@ sub install_or_remove_crontab {
             open CRON, $tmp_crontab or die "can't open $tmp_crontab: $!";
             while (<CRON>) {
                 if (/^MAILTO=(.*)$/) {
-                    system("/data/mysociety/bin/lookup_google_apps_email.py $1");
+                    system("/data/mysociety/bin/lookup_google_apps_email.sh $1");
                     my $result = $? >> 8;
                     if ($result == 1) {
                         unlink $tmp_crontab;
@@ -979,7 +979,7 @@ sub install_or_remove_crontab {
                     } elsif ($result == 2) {
                         warn "Google Apps API not working; can't check MAILTO address";
                     } elsif ($result != 0) {
-                        warn "unexpected result code $result from lookup_google_apps_email.py";
+                        warn "unexpected result code $result from lookup_google_apps_email.sh";
                     }
 
                     last;

--- a/bin/lookup_google_apps_email.py
+++ b/bin/lookup_google_apps_email.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 #
 # Check if an email address exists in our Google Apps domain.
 #

--- a/bin/lookup_google_apps_email.sh
+++ b/bin/lookup_google_apps_email.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
+PYTHON=$(which python)
 if [ -e /opt/virtualenvs/google_legacy_oauth ]; then
-    . /opt/virtualenvs/google_legacy_oauth/.venv/bin/activate
+    PYTHON="/opt/virtualenvs/google_legacy_oauth/.venv/bin/python"
 fi
 
-/data/mysociety/bin/lookup_google_apps_email.py $1
-
+$PYTHON /data/mysociety/bin/lookup_google_apps_email.py $1

--- a/bin/lookup_google_apps_email.sh
+++ b/bin/lookup_google_apps_email.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ -e /opt/virtualenvs/google_legacy_oauth ]; then
+    . /opt/virtualenvs/google_legacy_oauth/.venv/bin/activate
+fi
+
+/data/mysociety/bin/lookup_google_apps_email.py $1
+


### PR DESCRIPTION
The script used to verify Google Apps addresses needs an old version of the `oauth2client` package. This PR adds a wrapper script that checks for and activates a virtualenv before running the script. The virtualenv is provisioned separately where needed by Puppet.