### PR TITLE
Defer email when stopping a site

### DIFF
--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -580,20 +580,13 @@ sub stop_site {
     # Stop crontab
     unlink($cron_name);
 
-    # Stop email forwarding
-    # XXX hmmm, maybe not such a good idea to stop this, as emails to, say
-    # WhatDoTheyknow, would then not be delivered while deploying new version
-    # of it. Really should replace with something that gets exim to try
-    # redelivery?
-    #
-    # XXXX Note that this commented-out code was written before support was
-    # added for .forward-foo files, and does not support them; so do not just
-    # blindly uncomment it.
-    #if ($conf->{'email'}) {
-    #    foreach my $email_user (keys %{$conf->{'email'}}) {
-    #        unlink("/home/$email_user/.forward");
-    #    }
-    #}
+    # Stop email forwarding - calls the disable-email script for each
+    # user specified in the $conf->{'email'} hash.
+    if ($conf->{'email'}) {
+        foreach my $email_user (keys %{$conf->{'email'}}) {
+            shell("su", "-", $email_user, "-c /data/mysociety/bin/disable-email activate");
+        }
+    }
 
     if (-d "$vhost_dir/docs") {
         if (-s "$servers_dir/vhosts/downs/${vhost}.html") {
@@ -924,11 +917,17 @@ sub make_dot_forward {
     my ($email_user, $script, $suffix) = @_;
     my $forward_file_name = defined($suffix) ? ".forward-$suffix" : ".forward";
 
+    # remove any backup files created by the disable-email script.
+    my $backup_file = glob("~${email_user}/${forward_file_name}.bak");
+    unlink $backup_file if -e $backup_file;
+
+    # Create new version.
     if ($conf->{ruby_version}){
         shell("su", "-", $email_user, "-c echo \"|/home/$conf->{'user'}/run-with-rbenv-path $vhost_dir/$vcspath/$script\" >~$email_user/$forward_file_name");
     } else {
         shell("su", "-", $email_user, "-c echo \"|$vhost_dir/$vcspath/$script\" >~$email_user/$forward_file_name");
     }
+
 }
 
 sub install_or_remove_crontab {

--- a/bin/disable-email
+++ b/bin/disable-email
@@ -27,18 +27,27 @@ EOF
 }
 
 function move_files {
-  echo Changing pwd to $HOME
   cd $HOME
   if stat -t .forward*.bak >/dev/null 2>&1 ; then
-    echo Looks like there are some backup files already present \($( ls .forward*.bak )\), aborting.
-    exit 75
-  else
-    for forward_file in .forward* ; do
-      echo Moving ${forward_file} to ${forward_file}.bak
-      mv ${forward_file} ${forward_file}.bak
-      echo Echoing '|/data/mysociety/bin/disable-email fail' to ${forward_file}
-      echo '|/data/mysociety/bin/disable-email fail' > ${forward_file}
+    for backup_file in .forward*.bak ; do
+      actual_file=$( echo $backup_file | sed -e 's/\.bak$//')
+      if grep -q '|/data/mysociety/bin/disable-email fail' $actual_file ; then
+        echo "==> disable-email: Forwarding already disabled for $actual_file, skipping."
+      else
+        echo "==> disable-email: Backup file $backup_file present but $actual_file active - aborting."
+        exit 75
+      fi
     done
+  else
+    if stat -t .forward* >/dev/null 2>&1 ; then
+      for forward_file in .forward* ; do
+        echo "==> disable-email: Moving ${forward_file} to ${forward_file}.bak"
+        mv ${forward_file} ${forward_file}.bak
+        echo '|/data/mysociety/bin/disable-email fail' > ${forward_file}
+      done
+    else
+      echo "==> disable-email: Cannot see any .forward files to disable."
+    fi
   fi
 }
 
@@ -48,11 +57,11 @@ function restore_files {
   if stat -t .forward*.bak >/dev/null 2>&1 ; then
     for forward_file in .forward*.bak ; do
       original_file=$( echo $forward_file | sed -e 's/.bak$//' )
-      echo Moving mv $forward_file to $original_file
+      echo "==> disable-email: Moving mv $forward_file to $original_file"
       mv $forward_file $original_file
     done
   else
-    echo Cannot see any backup files to restore.
+    echo "==> disable-email: Cannot see any backup files to restore."
     exit 75
   fi
 }


### PR DESCRIPTION
This adds support for automatically deferring email for when stopping a site. It also updates the script used to do this with some improvements to handle various edge cases and clearly flag the source of any output generated so it can be identified in the deploy output.