### PR TITLE
Database configuration refactor

### DIFF
--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -119,102 +119,41 @@ sub get_pgpw_string {
     return $params->{new_pgpw} ? "-n $database" : $database;
 }
 
-sub one_db_conf_php {
-    my ($params, $database) = @_;
-    my $port_line = '';
-    if ($params->{type} eq 'psql') {
-        $port_line = "define('OPTION_$params->{prefix}_DB_PORT', $params->{port});";
-    }
-    my $db_host = get_db_host($params);
-    my $pgpw_string = get_pgpw_string($params, $database);
-
-    my $conf = <<END;
-define('OPTION_$params->{prefix}_DB_HOST', '$db_host');
-$port_line
-define('OPTION_$params->{prefix}_DB_NAME', '$database');
-define('OPTION_$params->{prefix}_DB_USER', '$database');
-define('OPTION_$params->{prefix}_DB_PASS', '\${\\(pgpw('$pgpw_string'))}');
-END
-    return $conf;
-
-}
-
-sub one_db_conf_yml {
-    my ($params, $database) = @_;
-    my $port_line = '';
-    if ($params->{type} eq 'psql') {
-        $port_line = "$params->{prefix}_DB_PORT: $params->{port}";
-    }
-    my $db_host = get_db_host($params);
-    my $pgpw_string = get_pgpw_string($params, $database);
-
-    my $conf = <<END;
-$params->{prefix}_DB_HOST: '$db_host'
-$port_line
-$params->{prefix}_DB_NAME: '$database'
-$params->{prefix}_DB_USER: '$database'
-$params->{prefix}_DB_PASS: '\${\\(pgpw('$pgpw_string'))}'
-END
-    return $conf;
-
-}
-
+# For each database, pull in information from the JSON and derive some
+# further data as required. Store this in $conf->{database_configs}
 sub db_conf {
     my ($params, $database) = @_;
     if ($params->{type} ne 'mysql' && $params->{type} ne 'psql' && $params->{type} ne 'mongo'){
         die "unknown database type '$params->{type}'";
     }
 
-    # Strings for PHP configuration
-    $conf->{database_configs}{default} .= one_db_conf_php($params, $database);
-
-    # Strings for YAML configuration
-    $conf->{database_configs}{yaml} .= one_db_conf_yml($params, $database);
-
     my $pgpw_string = get_pgpw_string($params, $database);
 
-    # Strings for Rails configuration
-    if ($params->{type} eq 'psql') {
-            # XXX doesn't cope with multiple Rails database configs (as you
-            # have to list them in the yml file in right place, so one text
-            # option can't), oh well
-            if (scalar(@{$conf->{'databases'}}) == 1) {
-                my $db_host = get_db_host($params);
-                $conf->{database_configs}{rails} = <<END;
-    adapter: postgresql
-    database: $database
-    username: $database
-    password: \${\\(pgpw('$pgpw_string'))}
-    host: $db_host
-    port: $params->{port}
-END
-            }
-    }
-    elsif ($params->{type} eq 'mysql') {
-            if (scalar(@{$conf->{'databases'}}) == 1) {
-                my $port = $params->{port} || 3306;
-                my $db_host = get_db_host($params);
-                $conf->{database_configs}{rails} = <<END;
-    adapter: mysql2
-    database: $database
-    username: $database
-    password: \${\\(pgpw('$pgpw_string'))}
-    host: $db_host
-    port: $port
-END
-            }
-    }
-
-    # Add all the parameters as structured data
-
-    push @{$conf->{struct_database_configs}}, {
-        prefix => $params->{prefix},
-        host => get_db_host($params, 0),
-        port => $params->{port},
-        name => $database,
+    my $db_config = {
+        prefix   => $params->{prefix},
+        host     => get_db_host($params),
+        name     => $database,
         username => $database,
         password => "\${\\(pgpw('$pgpw_string'))}",
     };
+
+    # All psql databases should have a port, MySQL often don't.
+    if ($params->{port}) {
+        $db_config->{port} = $params->{port};
+    }
+    elsif ($params->{type} eq 'mysql') {
+        $db_config->{port} = '3306';
+    }
+
+    if ($params->{type} eq 'mysql') {
+        $db_config->{adapter} = 'mysql2';
+    }
+    elsif ($params->{type} eq 'psql') {
+        $db_config->{adapter} = 'postgres'
+    }
+
+    # Add all the parameters as structured data to $conf.
+    push @{$conf->{database_configs}}, $db_config;
 
 }
 

--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -102,14 +102,14 @@ my $restart_apache = 0;
 # Helper functions
 
 sub get_db_host {
-    my ($params) = @_;
-    if ($params->{host} eq 'localhost') {
+    my $host = shift;
+    if ($host eq 'localhost') {
         # If the host is localhost, then it shouldn't be suffixed with
         # a domain:
-        return $params->{host};
+        return $host;
     } else {
         # Otherwise suffix it with a ukcod domain:
-        return "$params->{host}.ukcod.org.uk";
+        return "${host}.ukcod.org.uk";
     }
 }
 
@@ -131,7 +131,7 @@ sub db_conf {
 
     my $db_config = {
         prefix   => $params->{prefix},
-        host     => get_db_host($params),
+        host     => get_db_host($params->{host}),
         name     => $database,
         username => $database,
         password => "\${\\(pgpw('$pgpw_string'))}",
@@ -145,6 +145,13 @@ sub db_conf {
         $db_config->{port} = '3306';
     }
 
+    # Replica information.
+    if ($params->{replica}) {
+        $db_config->{replica_host} = get_db_host($params->{replica});
+        $db_config->{replica_port} = mySociety::Deploy::get_replica_port($db_config->{port});
+    }
+
+    # Adapter used by Rails configuration
     if ($params->{type} eq 'mysql') {
         $db_config->{adapter} = 'mysql2';
     }
@@ -1018,7 +1025,7 @@ sub remove_site {
 sub upgrade_db_password {
     my ($params, $database) = @_;
 
-    my $db_host = get_db_host($params);
+    my $db_host = get_db_host($params->{host});
 
     if ($params->{type} eq 'psql') {
         # Try to connect with the old password.  If we can't, assume upgrade already done.

--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -78,14 +78,6 @@ foreach my $dir (qw( conf_dir private_conf_dir )){
     $conf->{$dir} = $c;
 }
 
-# Read in relevant stuff from machine configuration file
-our ($internal_network);
-if (-f '/etc/mysociety/ec2') {
-    require "$servers_dir/machines/EC2.pl";
-} else {
-    require "$servers_dir/machines/$hostname.pl";
-}
-
 # Make database config settings
 if (defined $conf->{'databases'}) {
     foreach my $database (@{$conf->{'databases'}}) {
@@ -110,20 +102,14 @@ my $restart_apache = 0;
 # Helper functions
 
 sub get_db_host {
-    my ($params, $internal) = @_;
+    my ($params) = @_;
     if ($params->{host} eq 'localhost') {
         # If the host is localhost, then it shouldn't be suffixed with
         # a domain:
         return $params->{host};
     } else {
         # Otherwise suffix it with a ukcod domain:
-        my $network_part = '';
-        if ($internal && $internal_network) {
-            $network_part = 'int.ukcod.org.uk';
-        } else {
-            $network_part = 'ukcod.org.uk';
-        }
-        return "$params->{host}.$network_part";
+        return "$params->{host}.ukcod.org.uk";
     }
 }
 
@@ -134,12 +120,12 @@ sub get_pgpw_string {
 }
 
 sub one_db_conf_php {
-    my ($params, $database, $internal) = @_;
+    my ($params, $database) = @_;
     my $port_line = '';
     if ($params->{type} eq 'psql') {
         $port_line = "define('OPTION_$params->{prefix}_DB_PORT', $params->{port});";
     }
-    my $db_host = get_db_host($params, $internal);
+    my $db_host = get_db_host($params);
     my $pgpw_string = get_pgpw_string($params, $database);
 
     my $conf = <<END;
@@ -154,12 +140,12 @@ END
 }
 
 sub one_db_conf_yml {
-    my ($params, $database, $internal) = @_;
+    my ($params, $database) = @_;
     my $port_line = '';
     if ($params->{type} eq 'psql') {
         $port_line = "$params->{prefix}_DB_PORT: $params->{port}";
     }
-    my $db_host = get_db_host($params, $internal);
+    my $db_host = get_db_host($params);
     my $pgpw_string = get_pgpw_string($params, $database);
 
     my $conf = <<END;
@@ -180,12 +166,10 @@ sub db_conf {
     }
 
     # Strings for PHP configuration
-    $conf->{database_configs}{default} .= one_db_conf_php($params, $database, 1);
-    $conf->{database_configs}{external} .= one_db_conf_php($params, $database, 0);
+    $conf->{database_configs}{default} .= one_db_conf_php($params, $database);
 
     # Strings for YAML configuration
-    $conf->{database_configs}{yaml} .= one_db_conf_yml($params, $database, 1);
-    $conf->{database_configs}{external_yaml} .= one_db_conf_yml($params, $database, 0);
+    $conf->{database_configs}{yaml} .= one_db_conf_yml($params, $database);
 
     my $pgpw_string = get_pgpw_string($params, $database);
 
@@ -195,7 +179,7 @@ sub db_conf {
             # have to list them in the yml file in right place, so one text
             # option can't), oh well
             if (scalar(@{$conf->{'databases'}}) == 1) {
-                my $db_host = get_db_host($params, $internal_network);
+                my $db_host = get_db_host($params);
                 $conf->{database_configs}{rails} = <<END;
     adapter: postgresql
     database: $database
@@ -209,7 +193,7 @@ END
     elsif ($params->{type} eq 'mysql') {
             if (scalar(@{$conf->{'databases'}}) == 1) {
                 my $port = $params->{port} || 3306;
-                my $db_host = get_db_host($params, 0);
+                my $db_host = get_db_host($params);
                 $conf->{database_configs}{rails} = <<END;
     adapter: mysql2
     database: $database
@@ -223,17 +207,9 @@ END
 
     # Add all the parameters as structured data
 
-    push @{$conf->{struct_database_configs}{internal}}, {
+    push @{$conf->{struct_database_configs}}, {
         prefix => $params->{prefix},
         host => get_db_host($params, 0),
-        port => $params->{port},
-        name => $database,
-        username => $database,
-        password => "\${\\(pgpw('$pgpw_string'))}",
-    };
-    push @{$conf->{struct_database_configs}{external}}, {
-        prefix => $params->{prefix},
-        host => get_db_host($params, 1),
         port => $params->{port},
         name => $database,
         username => $database,
@@ -1103,7 +1079,7 @@ sub remove_site {
 sub upgrade_db_password {
     my ($params, $database) = @_;
 
-    my $db_host = get_db_host($params, 0);
+    my $db_host = get_db_host($params);
 
     if ($params->{type} eq 'psql') {
         # Try to connect with the old password.  If we can't, assume upgrade already done.

--- a/lib/mySociety/Deploy.pm
+++ b/lib/mySociety/Deploy.pm
@@ -140,6 +140,18 @@ sub server_name {
     return $server_name;
 }
 
+# Maps database ports to replica ports.
+sub get_replica_port {
+    my $port = shift;
+    my $ports = {
+        5432 => '5433',
+        5433 => '5432',
+        3306 => '3344',
+        3344 => '3306',
+    }
+    return $ports->{$port};
+}
+
 sub write_settings_file {
     my ($settings_file, $conf) = @_;
     my $settings_file_namepart = basename($settings_file);
@@ -186,7 +198,9 @@ END
         print FH "\$database_configs = <<DONE_DATABASE_CONFIGS;\n";
         foreach my $db (@{$conf->{database_configs}}) {
             print FH "define('OPTION_$db->{prefix}_DB_HOST', '$db->{host}');\n";
-            print FH "define('OPTION_$db->{prefix}_DB_PORT', $db->{port};\n" if $db->{port};
+            print FH "define('OPTION_$db->{prefix}_DB_PORT', $db->{port};\n"               if $db->{port};
+            print FH "define('OPTION_$db->{prefix}_DB_RO_HOST', '$db->{replica_host}');\n" if $db->{replica_host};
+            print FH "define('OPTION_$db->{prefix}_DB_RO_PORT', $db->{replica_port});\n"   if $db->{replica_port};
             print FH "define('OPTION_$db->{prefix}_DB_NAME', '$db->{name}');\n";
             print FH "define('OPTION_$db->{prefix}_DB_USER', '$db->{username}');\n";
             print FH "define('OPTION_$db->{prefix}_DB_PASS', '$db->{password}');\n";
@@ -197,7 +211,9 @@ END
         print FH "\$database_configs_yml = <<DONE_DATABASE_CONFIGS_YML;\n"
         foreach my $db (@{$conf->{database_configs}}) {
             print FH "$db->{prefix}_DB_HOST: '$db->{host}'\n";
-            print FH "$db->{prefix}_DB_PORT: $db->{port}\n" if $db->{port};
+            print FH "$db->{prefix}_DB_PORT: $db->{port}\n"              if $db->{port};
+            print FH "$db->{prefix}_DB_RO_HOST: '$db->{replica_host}'\n" if $db->{replica_host};
+            print FH "$db->{prefix}_DB_RO_PORT: $db->{replica_port}\n"   if $db->{replica_port};
             print FH "$db->{prefix}_DB_NAME: '$db->{name}'\n";
             print FH "$db->{prefix}_DB_USER: '$db->{username}'\n";
             print FH "$db->{prefix}_DB_PASS: '$db->{password}'\n";
@@ -225,7 +241,9 @@ END
         # Individual Variables for use with arbitrary formats.
         foreach my $db (@{$conf->{database_configs}}) {
             print FH "\$db_config_$db->{prefix}_host = '$db->{host}';\n";
-            print FH "\$db_config_$db->{prefix}_port = $db->{port};\n" if $db->{port};
+            print FH "\$db_config_$db->{prefix}_port = $db->{port};\n"             if $db->{port};
+            print FH "\$db_config_$db->{prefix}_ro_host = '$db->{replica_host}'\n" if $db->{replica_host};
+            print FH "\$db_config_$db->{prefix}_ro_port = $db->{replica_port}\n"   if $db->{replica_port};
             print FH "\$db_config_$db->{prefix}_name = '$db->{name}';\n";
             print FH "\$db_config_$db->{prefix}_username = '$db->{username}';\n";
             print FH "\$db_config_$db->{prefix}_password = $db->{password};\n";

--- a/lib/mySociety/Deploy.pm
+++ b/lib/mySociety/Deploy.pm
@@ -120,11 +120,7 @@ sub setup_conf {
     $conf->{request_timeout} = '' if !exists($conf->{request_timeout});
     $conf->{ruby_version} = '' if !exists($conf->{ruby_version});
     $conf->{rbenv_global} = 0 if !exists($conf->{rbenv_global});
-    $conf->{database_configs} = {
-        default => '',
-        yaml => '',
-        rails => '',
-    };
+    $conf->{database_configs} = [];
     return $conf;
 }
 
@@ -182,23 +178,58 @@ sub write_settings_file {
 \$randomly = '/data/mysociety/bin/randomly -p 0.5'; # for crontab
 \$ruby_version = '$conf->{ruby_version}';
 \$rbenv_global = '$conf->{rbenv_global}';
-\$database_configs = <<DONE_DATABASE_CONFIGS;
-$conf->{database_configs}{default}
-DONE_DATABASE_CONFIGS
-\$database_configs_yml = <<DONE_DATABASE_CONFIGS_YML;
-$conf->{database_configs}{yaml}
-DONE_DATABASE_CONFIGS_YML
-\$rails_database_config = <<DONE_RAILS_DATABASE_CONFIG;
-$conf->{database_configs}{rails}
-DONE_RAILS_DATABASE_CONFIG
 END
 
-    foreach my $db (@{$conf->{struct_database_configs}) {
-        print FH "\$db_config_$db->{prefix}_host = '$db->{host}';\n";
-        print FH "\$db_config_$db->{prefix}_port = $db->{port};\n" if $db->{port};
-        print FH "\$db_config_$db->{prefix}_name = '$db->{name}';\n";
-        print FH "\$db_config_$db->{prefix}_username = '$db->{username}';\n";
-        print FH "\$db_config_$db->{prefix}_password = $db->{password};\n";
+    # If there is database config, write it out in the various supported formats.
+    if ($conf->{database_configs}) {
+        # PHP Config
+        print FH "\$database_configs = <<DONE_DATABASE_CONFIGS;\n";
+        foreach my $db (@{$conf->{database_configs}}) {
+            print FH "define('OPTION_$db->{prefix}_DB_HOST', '$db->{host}');\n";
+            print FH "define('OPTION_$db->{prefix}_DB_PORT', $db->{port};\n" if $db->{port};
+            print FH "define('OPTION_$db->{prefix}_DB_NAME', '$db->{name}');\n";
+            print FH "define('OPTION_$db->{prefix}_DB_USER', '$db->{username}');\n";
+            print FH "define('OPTION_$db->{prefix}_DB_PASS', '$db->{password}');\n";
+        }
+        print FH "DONE_DATABASE_CONFIGS\n";
+
+        # YAML Config
+        print FH "\$database_configs_yml = <<DONE_DATABASE_CONFIGS_YML;\n"
+        foreach my $db (@{$conf->{database_configs}}) {
+            print FH "$db->{prefix}_DB_HOST: '$db->{host}'\n";
+            print FH "$db->{prefix}_DB_PORT: $db->{port}\n" if $db->{port};
+            print FH "$db->{prefix}_DB_NAME: '$db->{name}'\n";
+            print FH "$db->{prefix}_DB_USER: '$db->{username}'\n";
+            print FH "$db->{prefix}_DB_PASS: '$db->{password}'\n";
+        }
+        print FH "DONE_DATABASE_CONFIGS_YML\n";
+
+        # Rails config
+        # This doesn't cope with multiple Rails database configs (as you
+        # have to list them in the yml file in right place, so one text
+        # option can't). If you need to connect to multiple databases from
+        # Rails, you'll need to template the configuration using the
+        # individual variables generated in the next step.
+        if (scalar(@{$conf->{database_configs}}) == 1) {
+            my $db = ${$conf->{database_configs}}[0];
+            print FH "\$rails_database_config = <<DONE_RAILS_DATABASE_CONFIG;";
+            print FH "    adapter: $db->{adapter}\n";
+            print FH "    database: $db->{name}\n";
+            print FH "    username: $db->{username}\n";
+            print FH "    password: $db->{password}\n";
+            print FH "    host: $db->{host}\n";
+            print FH "    port: $db->{port}\n";
+            print FH "DONE_RAILS_DATABASE_CONFIG\n";
+        }
+
+        # Individual Variables for use with arbitrary formats.
+        foreach my $db (@{$conf->{database_configs}}) {
+            print FH "\$db_config_$db->{prefix}_host = '$db->{host}';\n";
+            print FH "\$db_config_$db->{prefix}_port = $db->{port};\n" if $db->{port};
+            print FH "\$db_config_$db->{prefix}_name = '$db->{name}';\n";
+            print FH "\$db_config_$db->{prefix}_username = '$db->{username}';\n";
+            print FH "\$db_config_$db->{prefix}_password = $db->{password};\n";
+        }
     }
 
     print FH Dumper($conf->{conf_dir});

--- a/lib/mySociety/Deploy.pm
+++ b/lib/mySociety/Deploy.pm
@@ -122,9 +122,7 @@ sub setup_conf {
     $conf->{rbenv_global} = 0 if !exists($conf->{rbenv_global});
     $conf->{database_configs} = {
         default => '',
-        external => '',
         yaml => '',
-        external_yaml => '',
         rails => '',
     };
     return $conf;
@@ -193,28 +191,14 @@ DONE_DATABASE_CONFIGS_YML
 \$rails_database_config = <<DONE_RAILS_DATABASE_CONFIG;
 $conf->{database_configs}{rails}
 DONE_RAILS_DATABASE_CONFIG
-\$external_database_configs = <<DONE_EXTERNAL_DATABASE_CONFIGS;
-$conf->{database_configs}{external}
-DONE_EXTERNAL_DATABASE_CONFIGS
-\$external_database_configs_yml = <<DONE_EXTERNAL_DATABASE_CONFIGS_YML;
-$conf->{database_configs}{external_yaml}
-DONE_EXTERNAL_DATABASE_CONFIGS_YML
 END
 
-    foreach my $db (@{$conf->{struct_database_configs}{internal}}) {
+    foreach my $db (@{$conf->{struct_database_configs}) {
         print FH "\$db_config_$db->{prefix}_host = '$db->{host}';\n";
         print FH "\$db_config_$db->{prefix}_port = $db->{port};\n" if $db->{port};
         print FH "\$db_config_$db->{prefix}_name = '$db->{name}';\n";
         print FH "\$db_config_$db->{prefix}_username = '$db->{username}';\n";
         print FH "\$db_config_$db->{prefix}_password = $db->{password};\n";
-    }
-
-    foreach my $db (@{$conf->{struct_database_configs}{external}}) {
-        print FH "\$db_config_$db->{prefix}_external_host = '$db->{host}';\n";
-        print FH "\$db_config_$db->{prefix}_external_port = $db->{port};\n" if $db->{port};
-        print FH "\$db_config_$db->{prefix}_external_name = '$db->{name}';\n";
-        print FH "\$db_config_$db->{prefix}_external_username = '$db->{username}';\n";
-        print FH "\$db_config_$db->{prefix}_external_password = $db->{password};\n";
     }
 
     print FH Dumper($conf->{conf_dir});


### PR DESCRIPTION
This PR adds variables for replica databases to the database configuration generated by the deployment scripts, derived from the `replica` value in the database JSON and some logic to work out the appropriate port.

It also includes a wider refactor that moves the generation of the various different formats out of the `deploy-vhost` script and into the `write_settings_file` function in `Deploy.pm` which feels like a more natural place as well as removing checks for whether we are on an internal network and an include of the older machine settings file used for a single associated variable.