### PR TITLE
 Read STDIN in top-scope rather that inside foreach loop 

### DIFF
--- a/bin/git-post-receive-hook-auto-deploy
+++ b/bin/git-post-receive-hook-auto-deploy
@@ -14,6 +14,16 @@ my $REPOSITORY_NAME = $ARGV[0];
 our ($sites, $vhosts);
 do '/data/vhosts.pl';
 
+### Get pushed branches from the 3rd argument of each line of stdin.
+my @pushed_branches;
+while(<STDIN>) {
+    my ($oldrev, $newrev, $refname) = split /\s+/;
+    my ($ref, $head, $branch) = split /\//, $refname, 3;
+    if(!grep(/^$branch$/, @pushed_branches)) {
+        push @pushed_branches, $branch;
+    }
+}
+
 ### Make a list of things we want to do
 
 my %actions;
@@ -49,16 +59,6 @@ foreach my $vhost (keys %$vhosts) {
 
     ### Ignore if its repo doesn't match the one that was just pushed to
     next if($REPOSITORY_NAME ne $vhost_git_repo);
-
-    ### Get pushed branches from the 3rd argument of each line of stdin.
-    my @pushed_branches;
-    while(<STDIN>) {
-        my ($oldrev, $newrev, $refname) = split /\s+/;
-        my ($ref, $head, $branch) = split /\//, $refname, 3;
-        if(!grep(/^$branch$/, @pushed_branches)) {
-            push @pushed_branches, $branch;
-        }
-    }
 
     ### Ignore if the branch used by this vhost wasn't pushed this time.
     next if(!grep(/^$vhost_git_branch$/, @pushed_branches));

--- a/bin/git-post-receive-hook-auto-deploy
+++ b/bin/git-post-receive-hook-auto-deploy
@@ -3,8 +3,6 @@
 # Look in vhosts.pl for vhosts configured to use this repo.  If any of them have
 # the 'auto_deploy' flag set, try to deploy them.
 #
-# $Id: git-post-receive-hook-auto-deploy,v 1.4 2013-07-11 13:35:05 ian Exp $
-#
 
 use strict;
 use warnings;


### PR DESCRIPTION
Where a site has multiple vhosts with `push_actions` defined, only the first encountered would be acted upon as `STDIN` was being read within the scope of the foreach loop and the `@pushed_branches` array would be empty on any further passes.

This moves the consumption of `STDIN` to the top-scope, preserving the state of `@pushed_branches` across the subsequent loops.