### PR TITLE
[deploy-vhost] ensure `touch_to_restart` is owned by app user 

### DIFF
--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -184,9 +184,8 @@ sub graceful {
     } else {
         my $touch = "$vhost_dir/$vcspath/$conf->{touch_to_restart}";
         utime(undef, undef, $touch)
-            || open(TMP, ">>", $touch)
+            || shell("su", "-", $conf->{'user'}, "-c touch $touch")
             || apache_graceful();
-        close TMP;
     }
 
     # ...and nginx


### PR DESCRIPTION
Rather than call `open` directly to create a new `touch_to_restart` file use the `shell` function to call `touch` directly as the appropriate application user.