### PR TITLE
Some small deploy script improvements

### DIFF
--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -37,15 +37,18 @@ mySociety::Deploy::read_conf($servers_dir);
 # Check command line parameters, look up in config file
 die "Specify virtual host name as first parameter, deploy/stop/update/start/remove/servers as second parameter" if scalar(@ARGV) < 2;
 
-my $vhost = $ARGV[0];
+my $vhost = shift @ARGV;
 
-my $action = $ARGV[1];
+my $action = shift @ARGV;
 die "Specify 'deploy', 'stop', 'update', 'start', 'servers' or 'remove' as second parameter" if $action ne "deploy" && $action ne "stop" && $action ne "update" && $action ne "start" && $action ne 'remove' && $action ne 'servers';
 
 my $flush = 0;
-$flush = 1 if @ARGV > 2 && $ARGV[2] eq '--flush';
 my $force = 0;
-$force = 1 if @ARGV > 2 && $ARGV[2] eq '--force';
+
+foreach my $other_arg (@ARGV) {
+    $flush = 1 if $other_arg eq '--flush';
+    $force = 1 if $other_arg eq '--force';
+}
 
 my $hostname = `hostname`;
 chomp($hostname);

--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -449,9 +449,21 @@ if ($action eq "stop") {
         print "Note: $vhost is also on " . join (', ', @other_hosts) . "\n";
     }
     if ($flush) {
-        use mySociety::Memcached;
-        mySociety::Memcached::flush_all();
-        print `varnishadm -T localhost:6082 -S /etc/varnish/secret purge req.http.host == "$vhost"`;
+        # Memcache
+        # This doesn't work, leaving it here as a reminder to look in future
+        #use mySociety::Memcached;
+        #mySociety::Memcached::flush_all();
+
+        # Varnish
+        # Ban the main vhost
+        print "Flushing Varnish...\n";
+        print `varnishadm ban "req.http.host == $vhost"`;
+        # And any aliases
+        if ($conf->{aliases}) {
+            foreach my $alias (@{$conf->{aliases}}) {
+                print `varnishadm ban "req.http.host == $alias"`;
+            }
+        }
     }
     if ($conf->{'sphinx'}) {
         sphinx_restart();

--- a/bin/mysociety
+++ b/bin/mysociety
@@ -20,10 +20,12 @@ Usage: mysociety [-u] COMMAND [OPTIONS]
 COMMAND is one of:
     config
         Tell Puppet to pull new manifests and apply them
-    vhost [--server server] [--all] VHOST
-	Deploy latest version of VHOST, e.g. www.pledgebank.com,
+    vhost [--server server | --all] VHOST [--force] [--flush]
+	    Deploy latest version of VHOST, e.g. www.pledgebank.com,
         optionally on [server] or, with --all, on all VHOST's servers
-    vhost stop/update/start [--server server] VHOST
+        --force will override any local uncommitted changes
+        --flush will ban VHOST and its aliases from local Varnish
+    vhost stop/update/start [--server server | --all] VHOST
         Stop/update/start VHOST, e.g. www.pledgebank.com
     vhost remove VHOST
         Remove crontab, Apache config, email forwards etc. for VHOST
@@ -150,7 +152,7 @@ case $COMMAND in
             shift || die "specify a vhost"
             if [ "$COMMAND" == "deploy" ]; then COMMAND=""; fi
             for s in $(mysociety vhost servers "$VHOST"); do
-                echo ssh -t "$s" sudo mysociety vhost "$COMMAND" "$VHOST"
+                echo ssh -t "$s" sudo mysociety vhost "$COMMAND" "$VHOST" "$@"
             done
             exit
         fi
@@ -162,7 +164,7 @@ case $COMMAND in
             shift || die "specify a vhost"
             if [ "$COMMAND" == "deploy" ]; then COMMAND=""; fi
             for s in $SERVER; do
-                ssh -t "$s" sudo mysociety vhost "$COMMAND" "$VHOST"
+                ssh -t "$s" sudo mysociety vhost "$COMMAND" "$VHOST" "$@"
             done
             exit
         fi

--- a/bin/mysociety
+++ b/bin/mysociety
@@ -152,7 +152,7 @@ case $COMMAND in
             shift || die "specify a vhost"
             if [ "$COMMAND" == "deploy" ]; then COMMAND=""; fi
             for s in $(mysociety vhost servers "$VHOST"); do
-                echo ssh -t "$s" sudo mysociety vhost "$COMMAND" "$VHOST" "$@"
+                ssh -t "$s" sudo mysociety vhost "$COMMAND" "$VHOST" "$@"
             done
             exit
         fi


### PR DESCRIPTION
This does the following:

* enables the `--all` option
* passes extra options to both `--all` and `--servers`
* updates the help text with more notes on --servers/--all and the other options
* fixes the `--flush` option to permit banning things in Varnish
* permits both `--flush` and `--force` to be passed if desired