### PR TITLE
Remove nodes from load-balancers during deploy

### DIFF
--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -40,7 +40,7 @@ die "Specify virtual host name as first parameter, deploy/stop/update/start/remo
 my $vhost = shift @ARGV;
 
 my $action = shift @ARGV;
-die "Specify 'deploy', 'stop', 'update', 'start', 'servers' or 'remove' as second parameter" if $action ne "deploy" && $action ne "stop" && $action ne "update" && $action ne "start" && $action ne 'remove' && $action ne 'servers';
+die "Specify 'deploy', 'stop', 'update', 'start', 'servers', 'balancers' or 'remove' as second parameter" if $action ne "deploy" && $action ne "stop" && $action ne "update" && $action ne "start" && $action ne 'remove' && $action ne 'servers' && $action ne 'balancers';
 
 my $flush = 0;
 my $force = 0;
@@ -65,6 +65,13 @@ my $vcspath = $conf->{vcspath};
 
 if ($action eq 'servers') {
     print join("\n", @{$conf->{servers}}) . "\n";
+    exit;
+}
+
+if ($action eq 'balancers') {
+    if ($conf->{balancers}) {
+        print join("\n", @{$conf->{balancers}}) . "\n";
+    }
     exit;
 }
 

--- a/bin/mysociety
+++ b/bin/mysociety
@@ -151,6 +151,10 @@ case $COMMAND in
             VHOST=$1
             shift || die "specify a vhost"
             if [ "$COMMAND" == "deploy" ]; then COMMAND=""; fi
+            if [ -r /etc/mysociety/slack.webhook ]; then
+                SLACK=`cat /etc/mysociety/slack.webhook`
+                curl --silent -X POST --data-urlencode 'payload={"channel": "#activity", "username": "DeployBot", "text": "'"[$HOST] $(logname) is deploying $VHOST on all servers"'", "icon_emoji": ":ms:"}' $SLACK >/dev/null
+            fi
             BALANCERS=$(mysociety vhost balancers "$VHOST")
             SERVERS=$(mysociety vhost servers "$VHOST")
             VHOST_BACKEND=$(echo $VHOST | sed -e 's/\./_/g')

--- a/bin/mysociety
+++ b/bin/mysociety
@@ -151,8 +151,38 @@ case $COMMAND in
             VHOST=$1
             shift || die "specify a vhost"
             if [ "$COMMAND" == "deploy" ]; then COMMAND=""; fi
-            for s in $(mysociety vhost servers "$VHOST"); do
+            BALANCERS=$(mysociety vhost balancers "$VHOST")
+            SERVERS=$(mysociety vhost servers "$VHOST")
+            VHOST_BACKEND=$(echo $VHOST | sed -e 's/\./_/g')
+            for s in $SERVERS; do
+                if [ -n "$BALANCERS" ]; then
+                    # remove server from balancers...
+                    for b in $BALANCERS; do
+                        echo -e "\033[34m[deploy] Removing ${VHOST} on ${s} from balancer ${b}...\033[0m"
+                        sudo varnishadm -S /etc/varnish/secret -T ${b}:6082 backend.set_health boot.${VHOST_BACKEND}_${s} sick
+                    done
+                fi
+                echo -e "\033[34m[deploy] Deploying ${VHOST} on ${s}...\033[0m"
                 ssh -t "$s" sudo mysociety vhost "$COMMAND" "$VHOST" "$@"
+                # This should provide a bit of time for process manager to start, or at least have the
+                # probe mark the back-end as sick before we switch back to auto - otherwise we sometimes
+                # see a couple of 503 responses before this happens.
+                sleep 10
+                if [ -n "$BALANCERS" ]; then
+                    # add server to balancers and wait until healthy...
+                    for b in $BALANCERS; do
+                        echo -e "\033[34m[deploy] Adding ${VHOST} on ${s} to balancer ${b}..."
+                        sudo varnishadm -S /etc/varnish/secret -T ${b}:6082 backend.set_health boot.${VHOST_BACKEND}_${s} auto
+                        # This check will ensure we don't start the next leg of the deploy
+                        # until the instance is healthy on both load balancers.
+                        until varnishadm -S /etc/varnish/secret -T ${b}:6082 backend.list boot.${VHOST_BACKEND}_${s} | tail -n +2 | grep -q Healthy
+                        do
+                            echo -n "."
+                            sleep 1
+                        done
+                        echo -e "[deploy] ${VHOST} on ${s} is healthy - done.\033[0m"
+                    done
+                fi
             done
             exit
         fi

--- a/bin/mysociety
+++ b/bin/mysociety
@@ -140,7 +140,7 @@ case $COMMAND in
         COMMAND=deploy
         VHOST=$1
         shift || die "specify a command or a virtual host"
-        if [ "$VHOST" == "stop" -o "$VHOST" == "update" -o "$VHOST" == "start" -o "$VHOST" == "remove" -o "$VHOST" == "servers" ]
+        if [ "$VHOST" == "stop" -o "$VHOST" == "update" -o "$VHOST" == "start" -o "$VHOST" == "remove" -o "$VHOST" == "servers" -o "$VHOST" == "balancers" ]
         then
             COMMAND=$VHOST
             VHOST=$1


### PR DESCRIPTION
This change will ensure that nodes are removed from the load-balancers when deploying with the `--all` switch, reducing the probability of end-users receiving errors due to failed back-end fetches.

As part of this, it also adds a `balancers` option to the deploy script that will simply return a list of load balancers associated with a given vhost.

It will also post a Slack notification that the deploy is taking place tagged with the logname of the user running the deploy.