### PR TITLE
Add a GitHub Action to bump the tag on the master branch

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -14,3 +14,4 @@ jobs:
       uses: anothrNick/github-tag-action@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        INITIAL_VERSION: 1.0.0


### PR DESCRIPTION
This uses The Github Tag Bump action to automatically bump and tag the master branch with the latest semver formatted version number. This can then be used to trigger a package build.

See: https://github.com/marketplace/actions/github-tag-bump

I've deliberately used the `master` branch of the action for now, but will settle on a specific release if appropriate.