### PR TITLE
Add conf variable for $vcspath_install

### DIFF
--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -84,6 +84,7 @@ my $timestamp = gmtime->strftime('%Y-%m-%dT%H-%M-%S');
 if ($timestamped_deploy && $action eq "deploy") {
     $vcspath_install = "$vcspath-$timestamp";
 }
+$conf->{vcspath_install} = $vcspath_install;
 
 # Ensure that the conf_dir and private_conf_dir elements are references to a list of config dirs.
 foreach my $dir (qw( conf_dir private_conf_dir )){

--- a/lib/mySociety/Deploy.pm
+++ b/lib/mySociety/Deploy.pm
@@ -174,6 +174,7 @@ sub write_settings_file {
 \$vhost = '$conf->{vhost}';
 \$vhost_dir = '$conf->{vhost_dir}';
 \$vcspath = '$conf->{vcspath}';
+\$vcspath_install = '$conf->{vcspath_install}';
 \$site = '$conf->{site}';
 \$staging = '$conf->{staging}';
 \$vhost_first = '$vhost_first';


### PR DESCRIPTION
This would be useful when processing ugly files.

For example we could add:
!!(*
  my $pro = `grep ^ENABLE_ALAVETELI_PRO $vhost_dir/$vcspath_install/config/general.yml | grep true | sed -n '\$='` || 0;
)!!

This would allow us to workout if Alaveteli Pro is enabled and later
conditionally add to the crontab if enabled. Currently we manually
maintain a list of vhosts in the config_crontab.ugly file which is
easily missed when upgrading a vhost.

We can't use the existing $vcspath variable as this is the final symlink
location of the vhost path. We need access to the timestamped path as
the ugly file processing happens before the symlinking.