### PR TITLE
Support for Docker and Noiseworks plus small fixes for newer Debian versions

### DIFF
--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -113,6 +113,11 @@ $cron_name = "/etc/cron.d/$cron_name";
 # the touch_to_restart config option (otherwise it always restarts).
 my $restart_apache = 0;
 
+# If we're using Docker, set a suitable stack name
+if ($conf->{docker}) {
+    ($conf->{docker}{stack} = $vhost) =~ s/\./_/g;
+}
+
 #####################################################################
 # Helper functions
 
@@ -193,17 +198,21 @@ sub nginx_graceful {
 }
 
 sub graceful {
-    # Prompt webserver to reread files, on machines which have apache...
-    if (!$conf->{touch_to_restart} || $restart_apache) {
-        apache_graceful();
-    } else {
-        my $touch = "$vhost_dir/$vcspath/$conf->{touch_to_restart}";
-        utime(undef, undef, $touch)
-            || shell("su", "-", $conf->{'user'}, "-c touch $touch")
-            || apache_graceful();
+
+    # Docker doesn't use Apache
+    if (!$conf->{docker}) {
+        # Either gracefully restart Apache, or do a touch-to-restart if supported
+        if (!$conf->{touch_to_restart} || $restart_apache) {
+            apache_graceful();
+        } else {
+            my $touch = "$vhost_dir/$vcspath/$conf->{touch_to_restart}";
+            utime(undef, undef, $touch)
+                || shell("su", "-", $conf->{'user'}, "-c touch $touch")
+                || apache_graceful();
+        }
     }
 
-    # ...and nginx
+    # ...and nginx for everyone who needs it.
     nginx_graceful() if $conf->{'https'} eq 'nginx';
 }
 
@@ -397,17 +406,22 @@ sub update_system_config {
     # Create the daemon
     create_daemons();
 
-    # Create apache/nginx configuration stanzas
+    # Common pathname for Apache and Nginx.
     my $vhost_file = "virtualhosts.d/$vhost.conf";
 
-    my $temp_file = mktemp("/tmp/deploy-vhost-apache-XXXXXXXX");
-    my $apache_file = "/etc/apache2/$vhost_file";
-    mugly("$servers_dir/vhosts/single-vhost.conf.ugly", $temp_file);
-    if (!-e $apache_file || system("diff", "-u", $apache_file, $temp_file) != 0) {
-        $restart_apache = 1;
-        copy($temp_file, $apache_file);
+    # Don't do Apache things with Docker vhosts
+    if (!$conf->{docker}) {
+        # Create apache configuration stanza
+        my $temp_file = mktemp("/tmp/deploy-vhost-apache-XXXXXXXX");
+        my $apache_file = "/etc/apache2/$vhost_file";
+        mugly("$servers_dir/vhosts/single-vhost.conf.ugly", $temp_file);
+        if (!-e $apache_file || system("diff", "-u", $apache_file, $temp_file) != 0) {
+            $restart_apache = 1;
+            copy($temp_file, $apache_file);
+        }
     }
 
+    # Nginx
     my $nginx_file = "/etc/nginx/$vhost_file";
     if ($conf->{https} eq 'nginx') {
         mugly("$servers_dir/vhosts/single-vhost-nginx-https-proxy.conf.ugly", $nginx_file);
@@ -574,6 +588,10 @@ sub stop_site {
                 or die "failed to rename .down.html.new to down.html in $vhost_dir/docs: $!";
             chown($conf->{user_uid}, $conf->{user_gid}, "$vhost_dir/docs/down.html");
         }
+    }
+
+    if ($conf->{docker}) {
+        shell("/usr/local/bin/docker-server", $vhost, "$vcspath_install/$conf->{conf_dir}->[0]", "stop");
     }
 }
 
@@ -943,6 +961,11 @@ sub install_or_remove_crontab {
 }
 
 sub start_site {
+
+    if ($conf->{docker}) {
+        shell("/usr/local/bin/docker-server", $vhost, "$vcspath_install/$conf->{conf_dir}->[0]", "start");
+    }
+
     # Up notice
     unlink("$vhost_dir/docs/down.html") or do {
         # It doesn't matter if down.html has already been removed.

--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -56,7 +56,7 @@ chomp($hostname);
 my $debian_version = `lsb_release -rs`;
 chomp($debian_version);
 my ($debian_version_major, $debian_version_minor) = split /\./, $debian_version;
-my $init_system = $debian_version_major =~ /8|9/ ? 'systemd' : 'sysv';
+my $init_system = $debian_version_major >= 8 ? 'systemd' : 'sysv';
 
 my $conf = mySociety::Deploy::setup_conf($vhost);
 my $vhost_dir = $conf->{vhost_dir};

--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -26,6 +26,7 @@ use File::Path qw(make_path);
 use File::Copy;
 use File::Copy::Recursive qw(dircopy);
 use File::Temp qw(mktemp);
+use URI::Escape;
 
 our $verbose = $ENV{VERBOSE} ? 1 : 0;
 
@@ -150,11 +151,12 @@ sub db_conf {
     my $pgpw_string = get_pgpw_string($params, $database);
 
     my $db_config = {
-        prefix   => $params->{prefix},
-        host     => get_db_host($params->{host}),
-        name     => $database,
-        username => $database,
-        password => "\${\\(pgpw('$pgpw_string'))}",
+        prefix           => $params->{prefix},
+        host             => get_db_host($params->{host}),
+        name             => $database,
+        username         => $database,
+        password         => pgpw($pgpw_string),
+        password_escaped => uri_escape(pgpw($pgpw_string)), # RFC3986 escaped version for use in database connection URIs
     };
 
     # All psql databases should have a port, MySQL often don't.

--- a/bin/update-vhosts-json
+++ b/bin/update-vhosts-json
@@ -42,7 +42,7 @@ def main():
         u'sites': collect_json(u"sites"),
         u'vhosts': collect_json(u"vhosts", add_site_key=True)
     }
-    with open(OUTPUT_PATH, "wb") as f:
+    with open(OUTPUT_PATH, "w") as f:
         json.dump(output, f)
 
 if __name__ == '__main__':

--- a/lib/mySociety/Deploy.pm
+++ b/lib/mySociety/Deploy.pm
@@ -234,7 +234,7 @@ END
             print FH "    adapter: $db->{adapter}\n";
             print FH "    database: $db->{name}\n";
             print FH "    username: $db->{username}\n";
-            print FH "    password: $db->{password}\n";
+            print FH "    password: '$db->{password}'\n";
             print FH "    host: $db->{host}\n";
             print FH "    port: $db->{port}\n";
             print FH "DONE_RAILS_DATABASE_CONFIG\n";
@@ -248,7 +248,8 @@ END
             print FH "\$db_config_$db->{prefix}_ro_port = $db->{replica_port};\n"   if $db->{replica_port};
             print FH "\$db_config_$db->{prefix}_name = '$db->{name}';\n";
             print FH "\$db_config_$db->{prefix}_username = '$db->{username}';\n";
-            print FH "\$db_config_$db->{prefix}_password = $db->{password};\n";
+            print FH "\$db_config_$db->{prefix}_password = '$db->{password}';\n";
+            print FH "\$db_config_$db->{prefix}_password_escaped = '$db->{password_escaped}';\n";
         }
     }
 

--- a/lib/mySociety/Deploy.pm
+++ b/lib/mySociety/Deploy.pm
@@ -269,6 +269,11 @@ END
     print FH "\$redirects = \$VAR1;\n";
     print FH Dumper($conf->{aliases});
     print FH "\$aliases = \$VAR1;\n";
+    if ($conf->{docker}) {
+        print FH "# Docker configuration\n";
+        print FH Dumper($conf->{docker});
+        print FH "\$docker = \$VAR1;\n";
+    }
     print FH <<END;
 
 # ---------------------------------------------------------


### PR DESCRIPTION
Apologies for combining various things in a single PR.

This includes:

- initial support for Docker-based deployments
- assumes systemd for Debian >= 8 rather than checking specific releases (ensure's Bullseye, etc, use systemd)
- removes a call out to `pgpw` from the `settings-autogen.p`l files seeded during deployment in favour of the actual password
- adds an RFC3986 escaped version of the database passwords for use in connection URIs
- writes out the deployment JSON in string rather than binary context (Python3 fix for Bullseye)