### PR TITLE
[deploy-vhost] Use the `maint` user to update the servers repository

### DIFF
--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -609,7 +609,8 @@ sub get_conf_ugly_file_from_servers_dir {
   my ($conf_ugly_part) = @_;
   my $conf_ugly_file = "$servers_dir/vhosts/$vcspath/$vhost/$conf_ugly_part.ugly";
   # update the conf/general (or whatever) template in private git repo
-  shell("git", "-C", "$servers_dir/vhosts", "pull", "-q", "origin");
+  # Do this as the maint user, not as root, to avoid the need for root SSH
+  shell("su maint -c 'git -C $servers_dir/vhosts pull -q origin'");
   $conf_ugly_file = "$servers_dir/vhosts/$vcspath/$conf_ugly_part.ugly" unless -e $conf_ugly_file;
   $conf_ugly_file = "$servers_dir/vhosts/${vcspath}_$conf_ugly_part.ugly" unless -e $conf_ugly_file;
   return $conf_ugly_file;


### PR DESCRIPTION
As it stands, this operation requires root SSH to git.mysociety.org. We can use the `maint` user for this for now until we complete a wider review of how we manage building configuration for a deploy, removing the need for root SSH from application server instances to the git server and other internal systems.