### PR TITLE
[mysociety] Connect to Varnish via TLS secured reverse proxy

### DIFF
--- a/bin/generate-pgpass
+++ b/bin/generate-pgpass
@@ -18,10 +18,21 @@ use lib "$FindBin::Bin/../perllib";
 use POSIX;
 
 use mySociety::TempFiles;
-use mySociety::ServerClass;
 
 my $servers_dir = "$FindBin::Bin/../../servers";
 require "$servers_dir/vhosts.pl";
+
+# Get the local hostname
+my $hostname = (uname())[1];
+
+# Check if we're running on a backup server
+my $is_backupserver;
+if (-x "/opt/puppetlabs/bin/facter") {
+    $is_backupserver = `/opt/puppetlabs/bin/facter -p is_backupserver`;
+    chomp $is_backupserver;
+} else {
+    $is_backupserver = ( -e "/etc/cron.d/run-backup" ? "true" : "false" );
+}
 
 our ($vhosts, $sites, $databases);
 
@@ -79,18 +90,17 @@ foreach my $database_name (keys %$databases) {
 
     # ... on backup hosts, give root access to all databases
     if ($database_info->{backup}) {
-        foreach my $server (mySociety::ServerClass::all_servers_in_class("backups")) {
-            $perms{$server}{'root'}{$database_name} = 1;
-        }
+	if ($is_backupserver eq 'true') {
+	    $perms{$hostname}{'root'}{$database_name} = 1;
+	}
     }
 
     # ... add root access to databases not associated with vhosts
     $perms{$database_info->{host}}{'root'}{$database_name} = 1;
 }
 
-my $server = (uname())[1];
-my $database_permissions = $perms{$server};
-die "generate-pgpass not configured for server $server" unless $database_permissions;
+my $database_permissions = $perms{$hostname};
+die "generate-pgpass not configured for server $hostname" unless $database_permissions;
 
 foreach my $user (sort keys %$database_permissions) {
     my @x = getpwnam($user) or die "$user: getpwnam: $!";

--- a/bin/mysociety
+++ b/bin/mysociety
@@ -144,8 +144,9 @@ case $COMMAND in
                 if [ -n "$BALANCERS" ] && [ "$(echo $SERVERS | wc -w)" -gt 1 ]; then
                     # remove server from balancers if there are balancers and more than one server...
                     for b in $BALANCERS; do
-                        echo -e "\033[34m[deploy] Removing ${VHOST} on ${s} from balancer ${b}...\033[0m"
-                        sudo varnishadm -S /etc/varnish/secret -T ${b}:6082 backend.set_health boot.${VHOST_BACKEND} sick
+                        PORT=$(jq --arg lb "$(echo $b | cut -d. -f1)" -r '.[$lb]' /etc/mysociety/varnishadm.json)
+                        echo -e "\033[34m[deploy] Removing ${VHOST} on ${s} from balancer ${b} via localhost:${PORT}...\033[0m"
+                        sudo varnishadm -S /etc/varnish/secret -T localhost:${PORT} backend.set_health boot.${VHOST_BACKEND} sick
                         sleep 5
                     done
                 fi
@@ -158,12 +159,13 @@ case $COMMAND in
                     sleep 10
                     # Switch back to Auto, and if starting/deploying wait until healthy.
                     for b in $BALANCERS; do
-                        echo -e "\033[34m[deploy] Adding ${VHOST} on ${s} to balancer ${b}..."
-                        sudo varnishadm -S /etc/varnish/secret -T ${b}:6082 backend.set_health boot.${VHOST_BACKEND} auto
+                        PORT=$(jq --arg lb "$(echo $b | cut -d. -f1)" -r '.[$lb]' /etc/mysociety/varnishadm.json)
+                        echo -e "\033[34m[deploy] Adding ${VHOST} on ${s} to balancer ${b} via localhost:${PORT}..."
+                        sudo varnishadm -S /etc/varnish/secret -T localhost:${PORT} backend.set_health boot.${VHOST_BACKEND} auto
                         if [ "$COMMAND" != "stop" -a "$COMMAND" != "remove" ] ; then
                             # This check will ensure we don't start the next leg of the deploy
                             # until the instance is healthy on both load balancers.
-                            until varnishadm -S /etc/varnish/secret -T ${b}:6082 backend.list boot.${VHOST_BACKEND} | tail -n +2 | grep -iq Healthy
+                            until varnishadm -S /etc/varnish/secret -T localhost:${PORT} backend.list boot.${VHOST_BACKEND} | tail -n +2 | grep -iq Healthy
                             do
                                 echo -n "."
                                 sleep 1


### PR DESCRIPTION
Rather than connect directly to the Varnish management port on the load balancers, this change will instead connect via a reverse proxy so as to ensure the connection is encrypted on the wire.

Port mappings for the local end of the reverse proxy are expected to be found in `/etc/mysociety/varnishadm` which will be populated by our automation on management server instances from where it makes sense to run with the `--all` flag.