### PR TITLE
[deploy-vhost] adm group should be able to read vhost logs and applogs

### DIFF
--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -371,7 +371,7 @@ sub create_or_update_files {
         # Allow logs to be read on staging hosts so that tests can run
         # Protect logs on production hosts
         $conf->{staging} ? 0755 : 0750,
-        0, scalar(getgrnam('adm')));
+        $conf->{user_uid}, scalar(getgrnam('adm')));
     make_dir("$vhost_dir/applogs", 0750, $conf->{user_uid}, scalar(getgrnam('adm')));
     my $web_dir = $conf->{redirects_only} ?  "$vhost_dir/web" : "$vcspath/" . $conf->{web_dir};
     make_symlink($web_dir, "$vhost_dir/docs");

--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -371,8 +371,8 @@ sub create_or_update_files {
         # Allow logs to be read on staging hosts so that tests can run
         # Protect logs on production hosts
         $conf->{staging} ? 0755 : 0750,
-        0, scalar(getgrnam('staff')));
-    make_dir("$vhost_dir/applogs", 0750);
+        0, scalar(getgrnam('adm')));
+    make_dir("$vhost_dir/applogs", 0750, $conf->{user_uid}, scalar(getgrnam('adm')));
     my $web_dir = $conf->{redirects_only} ?  "$vhost_dir/web" : "$vcspath/" . $conf->{web_dir};
     make_symlink($web_dir, "$vhost_dir/docs");
     shell("chown", "-h", "$conf->{user_uid}:$conf->{user_gid}", "$vhost_dir/docs"); # perl's chown doesn't do symlinks


### PR DESCRIPTION
This will allow all engineering staff to access these directories. At present, you need to be a member of staff which is more restricted, be the vhost user, or use sudo.

See: https://github.com/mysociety/sysadmin/issues/1808