### PR TITLE
Systemd and daemon fixups

### DIFF
--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -387,14 +387,13 @@ sub create_daemons {
             print $fh "\$daemon_name = '$daemon';\n";
             if ($systemd) {
                 mugly($daemon_mugly, "/etc/systemd/system/${daemon}.service", $fh->filename);
-                shell("/bin/systemctl", "daemon-reload");
-                shell("/bin/systemctl", "enable", "$daemon");
             }
             else {
                 mugly($daemon_mugly, "/etc/init.d/$daemon", $fh->filename);
                 chmod 0755, "/etc/init.d/$daemon";
-                system("update-rc.d $daemon defaults | grep -v \"System startup links for .* already exist\"");
             }
+            shell("/bin/systemctl", "daemon-reload");
+            shell("/bin/systemctl", "enable", "$daemon");
         }
     } else {
         # They may have been deployed previously, but are no longer needed, so remove them.

--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -387,6 +387,8 @@ sub create_daemons {
             print $fh "\$daemon_name = '$daemon';\n";
             if ($systemd) {
                 mugly($daemon_mugly, "/etc/systemd/system/${daemon}.service", $fh->filename);
+                # In case we're transitioning from an older init script, make sure it's been removed.
+                unlink("/etc/init.d/$daemon") if -e "/etc/init.d/$daemon";
             }
             else {
                 mugly($daemon_mugly, "/etc/init.d/$daemon", $fh->filename);

--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -343,12 +343,12 @@ sub remove_daemons {
     # Remove daemons
     my $daemon_reload = 0;
     foreach my $daemon (keys %{$conf->{'daemons'}}) {
+        shell("/bin/systemctl", "disable", "$daemon");
         if (-e "/etc/init.d/$daemon") {
             unlink("/etc/init.d/$daemon");
             $daemon_reload = 1;
         }
         if (-e "/etc/systemd/system/${daemon}.service") {
-            shell("/bin/systemctl", "disable", "$daemon");
             unlink("/etc/systemd/system/${daemon}.service");
             $daemon_reload = 1;
         }


### PR DESCRIPTION
Some small improvements to systemd daemon integration.

- Make sure we remove any init script left over from a transition to a native systemd unit
- Always use system natively regardless of whether we're using a unit or an init script
- When removing daemons always disable them regardless of type

Fixes #33