### PR TITLE
[deploy-vhost] Only stop/disable daemons when definitely present

### DIFF
--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -343,13 +343,11 @@ sub remove_daemons {
     # Remove daemons
     my $daemon_reload = 0;
     foreach my $daemon (keys %{$conf->{'daemons'}}) {
-        shell("/bin/systemctl", "disable", "$daemon");
-        if (-e "/etc/init.d/$daemon") {
-            unlink("/etc/init.d/$daemon");
-            $daemon_reload = 1;
-        }
-        if (-e "/etc/systemd/system/${daemon}.service") {
-            unlink("/etc/systemd/system/${daemon}.service");
+        if (-e "/etc/systemd/system/${daemon}.service" || -e "/etc/init.d/$daemon") {
+            shell("/bin/systemctl", "stop", "$daemon");
+            shell("/bin/systemctl", "disable", "$daemon");
+            unlink("/etc/init.d/$daemon") if -e "/etc/init.d/$daemon";
+            unlink("/etc/systemd/system/${daemon}.service") if -e "/etc/systemd/system/${daemon}.service";
             $daemon_reload = 1;
         }
     }


### PR DESCRIPTION
Refactor `remove_daemons` to only attempt to disable a daemon where a unit file is present as this might be called from `create_daemons` when there are no daemons present.

Adds a call to stop the daemon to `remove_daemons` as on some paths they may still be running. Stopping an already stopped daemon is fine.

This also consolidates the code a bit, without breaking the assumption that there might be both a unit file and an init script present.

See: https://github.com/mysociety/misc-scripts/pull/80