### PR TITLE
Clean deploys tweaks

### DIFF
--- a/bin/clean-deploys
+++ b/bin/clean-deploys
@@ -89,7 +89,7 @@ foreach my $vhost ( @vhosts_to_check ) {
             $c++;
             $git_status = qx(git -C $deploy status --porcelain);
             if ($git_status) {
-                print "$vhost: timestamped deploy $deploy repo isn't clean.\n";
+                print "$vhost: timestamped deploy $deploy repo isn't clean.\n" if $verbose;
                 print "$git_status\n" if $verbose;
             }
             if ( !$git_status || $force ) {
@@ -110,7 +110,7 @@ foreach my $vhost ( @vhosts_to_check ) {
     } else {
         $git_status = qx(git -C ${vhosts_dir}/${vhost}/${repo} status --porcelain);
         if ($git_status) {
-            print "$vhost: repo isn't clean.\n";
+            print "$vhost: repo isn't clean.\n" if $verbose;
             print "$git_status\n" if $verbose;
         } else {
             print "$vhost: repo is clean.\n" if $verbose;

--- a/bin/clean-deploys
+++ b/bin/clean-deploys
@@ -17,6 +17,7 @@ my $quiet = 0;
 my $delete = 0;
 my $force = 0;
 my $help = 0;
+my $keep = 5;
 my @vhosts_to_check = ();
 my @ignore_vhosts = ( "${host}", "debian.mysociety.org" );
 my $vhosts_dir = "/data/vhost";
@@ -28,6 +29,7 @@ GetOptions(
     'delete'  => \$delete,
     'force'   => \$force,
     'help'    => \$help,
+    'keep=i'  => \$keep,
     'vhost=s' => \@vhosts_to_check,
 );
 
@@ -95,7 +97,7 @@ foreach my $vhost ( @vhosts_to_check ) {
                 print "$git_status\n" unless $quiet;
             }
             if ( !$git_status || $force ) {
-                if ( $c <= $num_deploys - 5 && $deploy ne $live_deploy ) {
+                if ( $c <= $num_deploys - $keep && $deploy ne $live_deploy ) {
                     # Let's just delete any older timestamped deploys, keeping around the most
                     # recent five. Note we're basing this on the order returned by sort() on
                     # the list of timestamped deploy directories, which should be fine as they
@@ -172,6 +174,10 @@ Using this option with B<--delete> will also delete any deploys that
 have untracked or changed files in the working copies. Using the option
 without the B<--delete> flag and without the B<--quiet> flag will add
 output stating which additional deploys would be deleted.
+
+=item --keep
+
+The number of old timestamped deploys to keep around. The default is 5.
 
 =item --vhost
 

--- a/bin/clean-deploys
+++ b/bin/clean-deploys
@@ -18,7 +18,7 @@ my $verbose = 0;
 my $delete = 0;
 my $help = 0;
 my @vhosts_to_check = ();
-my @ignore_vhosts = ( "default.ukcod.org.uk", "${host}.ukcod.org.uk", "debian.mysociety.org" );
+my @ignore_vhosts = ( "${host}", "debian.mysociety.org" );
 my $vhosts_dir = "/data/vhost";
 my $deployed_vhosts_state = "/var/lib/server-state/vhost-list";
 

--- a/bin/clean-deploys
+++ b/bin/clean-deploys
@@ -16,6 +16,7 @@ my $vhosts = mySociety::VHosts->new();
 
 my $verbose = 0;
 my $delete = 0;
+my $force = 0;
 my $help = 0;
 my @vhosts_to_check = ();
 my @ignore_vhosts = ( "${host}", "debian.mysociety.org" );
@@ -26,6 +27,7 @@ my $deployed_vhosts_state = "/var/lib/server-state/vhost-list";
 GetOptions(
     'verbose' => \$verbose,
     'delete'  => \$delete,
+    'force'   => \$force,
     'help'    => \$help,
     'vhost=s' => \@vhosts_to_check,
 );
@@ -89,16 +91,19 @@ foreach my $vhost ( @vhosts_to_check ) {
             if ($git_status) {
                 print "$vhost: timestamped deploy $deploy repo isn't clean.\n";
                 print "$git_status\n" if $verbose;
-            } elsif ( $c <= $num_deploys - 5 && $deploy ne $live_deploy ) {
-                # Let's just delete any older timestamped deploys, keeping around the most
-                # recent five. Note we're basing this on the order returned by sort() on
-                # the list of timestamped deploy directories, which should be fine as they
-                # contain sortable timestamps.
-                if ( $delete ) {
-                    rmtree( [ $deploy] );
-                    print "$vhost: deleted $deploy\n" if $verbose;
-                } else {
-                    print "$vhost: would delete $deploy\n" if $verbose;
+            }
+            if ( !$git_status || $force ) {
+                if ( $c <= $num_deploys - 5 && $deploy ne $live_deploy ) {
+                    # Let's just delete any older timestamped deploys, keeping around the most
+                    # recent five. Note we're basing this on the order returned by sort() on
+                    # the list of timestamped deploy directories, which should be fine as they
+                    # contain sortable timestamps.
+                    if ( $delete ) {
+                        rmtree( [ $deploy] );
+                        print "$vhost: deleted $deploy\n" if $verbose;
+                    } else {
+                        print "$vhost: would delete $deploy\n" if $verbose;
+                    }
                 }
             }
         }
@@ -157,6 +162,13 @@ notice. Recentness is simply determined using a sort on the directory
 names of the timestamped deploys. The current live deploy, as
 determined by the target of the symlink to the bare repository name,
 will not be deleted regardless of its place in the sort order.
+
+=item --force
+
+Using this option with B<--delete> will also delete any deploys that
+have untracked or changed files in the working copies. Using the option
+without the B<--delete> flag and without the B<--quiet> flag will add
+output stating which additional deploys would be deleted.
 
 =item --vhost
 

--- a/bin/clean-deploys
+++ b/bin/clean-deploys
@@ -12,7 +12,6 @@ my $host = hostname;
 use FindBin;
 use lib "$FindBin::Bin/../perllib";
 use mySociety::VHosts;
-my $vhosts = mySociety::VHosts->new();
 
 my $verbose = 0;
 my $delete = 0;
@@ -36,6 +35,8 @@ if ($help) {
     pod2usage(-exitval => 0, -verbose => 2);
     exit(0);
 }
+
+my $vhosts = mySociety::VHosts->new();
 
 # Unless provided with some on the commandline get a list of deployed
 # vhosts from the local state file.
@@ -139,6 +140,9 @@ for the current live copy).
 By default B<clean-deploys> will look at all vhosts listed in the
 current state file for the server in question. The B<--vhost> option
 (q.v.) can be used to specify particular vhosts to check.
+
+Note that aside from B<--help> all other operations expect a copy of
+`/data/servers/vhosts.pl` to be present on the system.
 
 =head1 OPTIONS
 

--- a/bin/clean-deploys
+++ b/bin/clean-deploys
@@ -13,7 +13,7 @@ use FindBin;
 use lib "$FindBin::Bin/../perllib";
 use mySociety::VHosts;
 
-my $verbose = 0;
+my $quiet = 0;
 my $delete = 0;
 my $force = 0;
 my $help = 0;
@@ -24,7 +24,7 @@ my $deployed_vhosts_state = "/var/lib/server-state/vhost-list";
 
 # Options
 GetOptions(
-    'verbose' => \$verbose,
+    'quiet' => \$quiet,
     'delete'  => \$delete,
     'force'   => \$force,
     'help'    => \$help,
@@ -46,7 +46,7 @@ unless ( @vhosts_to_check ) {
         $v =~ s/^\s+|\s+$//g;
         foreach ( @ignore_vhosts ) {
             if ( "$_" eq "$v" ) {
-                print "${v}: skipping - hardcoded exception.\n" if $verbose;
+                print "${v}: skipping - hardcoded exception.\n" unless $quiet;
                 next STATE;
             }
         }
@@ -62,7 +62,7 @@ foreach my $vhost ( @vhosts_to_check ) {
     if ( $vhosts->{vhosts}{$vhost} ) {
         $vhost_conf = $vhosts->vhost($vhost);
     } else {
-        print "$vhost: skipping - not in JSON.\n" if $verbose;
+        print "$vhost: skipping - not in JSON.\n" unless $quiet;
         next;
     }
     my $site_conf  = $vhosts->site($vhost_conf->{site});
@@ -72,7 +72,7 @@ foreach my $vhost ( @vhosts_to_check ) {
 
     # Skip Redirect Sites.
     if ( $conf->{redirects_only} ) {
-        print "$vhost: skipping - redirects only.\n" if $verbose;
+        print "$vhost: skipping - redirects only.\n" unless $quiet;
         next;
     }
 
@@ -88,11 +88,11 @@ foreach my $vhost ( @vhosts_to_check ) {
         my $c = 0;
         foreach my $deploy ( sort @deploys ) {
             $c++;
-            print "$vhost: working on the live deploy - ${deploy}\n" if ($verbose && $deploy eq $live_deploy);
+            print "$vhost: working on the live deploy - ${deploy}\n" if (!$quiet && $deploy eq $live_deploy);
             $git_status = qx(git -C $deploy status --porcelain);
             if ($git_status) {
-                print "$vhost: timestamped deploy $deploy repo isn't clean.\n" if $verbose;
-                print "$git_status\n" if $verbose;
+                print "$vhost: timestamped deploy $deploy repo isn't clean.\n" unless $quiet;
+                print "$git_status\n" unless $quiet;
             }
             if ( !$git_status || $force ) {
                 if ( $c <= $num_deploys - 5 && $deploy ne $live_deploy ) {
@@ -102,9 +102,9 @@ foreach my $vhost ( @vhosts_to_check ) {
                     # contain sortable timestamps.
                     if ( $delete ) {
                         rmtree( [ $deploy] );
-                        print "$vhost: deleted $deploy\n" if $verbose;
+                        print "$vhost: deleted $deploy\n" unless $quiet;
                     } else {
-                        print "$vhost: would delete $deploy\n" if $verbose;
+                        print "$vhost: would delete $deploy\n" unless $quiet;
                     }
                 }
             }
@@ -112,10 +112,10 @@ foreach my $vhost ( @vhosts_to_check ) {
     } else {
         $git_status = qx(git -C ${vhosts_dir}/${vhost}/${repo} status --porcelain);
         if ($git_status) {
-            print "$vhost: repo isn't clean.\n" if $verbose;
-            print "$git_status\n" if $verbose;
+            print "$vhost: repo isn't clean.\n" unless $quiet;
+            print "$git_status\n" unless $quiet;
         } else {
-            print "$vhost: repo is clean.\n" if $verbose;
+            print "$vhost: repo is clean.\n" unless $quiet;
         }
     }
 }
@@ -152,12 +152,10 @@ Note that aside from B<--help> all other operations expect a copy of
 
 Displays this help message.
 
-=item --verbose
+=item --quiet
 
-Provides more detailed information on untracked and changed files
-and reports on vhosts skipped where they are missing from the
-deployment JSON, configured only for redirects or are hardcoded as
-exceptions.
+This options will suppress all output except for errors, for example
+to run under cron.
 
 =item --delete
 

--- a/bin/clean-deploys
+++ b/bin/clean-deploys
@@ -87,6 +87,7 @@ foreach my $vhost ( @vhosts_to_check ) {
         my $c = 0;
         foreach my $deploy ( sort @deploys ) {
             $c++;
+            print "$vhost: working on the live deploy - ${deploy}\n" if ($verbose && $deploy eq $live_deploy);
             $git_status = qx(git -C $deploy status --porcelain);
             if ($git_status) {
                 print "$vhost: timestamped deploy $deploy repo isn't clean.\n" if $verbose;

--- a/bin/clean-deploys
+++ b/bin/clean-deploys
@@ -94,7 +94,7 @@ foreach my $vhost ( @vhosts_to_check ) {
             $git_status = qx(git -C $deploy status --porcelain);
             if ($git_status) {
                 print "$vhost: timestamped deploy $deploy repo isn't clean.\n" unless $quiet;
-                print "$git_status\n" unless $quiet;
+                print "$git_status" unless $quiet;
             }
             if ( !$git_status || $force ) {
                 if ( $c <= $num_deploys - $keep && $deploy ne $live_deploy ) {
@@ -106,7 +106,7 @@ foreach my $vhost ( @vhosts_to_check ) {
                         rmtree( [ $deploy] );
                         print "$vhost: deleted $deploy\n" unless $quiet;
                     } else {
-                        print "$vhost: would delete $deploy\n" unless $quiet;
+                        print "$vhost: would delete $deploy\n\n" unless $quiet;
                     }
                 }
             }


### PR DESCRIPTION
- Add a `--force` option that will remove old timestamped deploys even if they have uncommitted changes (most of these are deployment artefacts that have been omitted from the repo's `.gitignore`)
- Swap `--verbose` for `--quiet` option, so by default output is generated which seems like a more natural thing to do and more in-line with what you'd expect when running it by hand.
- When printing output, flag which is the live deploy when checking it for reference.
- Updates to the hardcoded exceptions section.
- Make sure that `--help` runs in the absence of `/data/servers/vhosts.pl`.
- Add a `--keep` options to permit control over the number of timestamped deploys to retain.