### PR TITLE
[mysociety-create-databases] Grant DB user access to public schema

### DIFF
--- a/bin/mysociety-create-databases
+++ b/bin/mysociety-create-databases
@@ -132,6 +132,13 @@ foreach my $database (keys %{$databases}) {
                 $dbh->do("alter user \"$database\" with createdb");
             }
 
+            # Give user permissions on public schema on PostgreSQL 15+
+            if ($pg_version >= 15) {
+                my $dbh_db = DBI->connect("dbi:Pg:dbname=$database;port=$params->{port}", 'postgres', undef, { PrintWarn => 1, PrintError => 1, RaiseError => 0, AutoCommit => 1 }) || die DBI->errstr();
+                $dbh_db->do("grant all on schema public to \"$database\" ");
+                $dbh_db->disconnect;
+            }
+
             push @out, "no change" if $::verbose && !@out;
             print "$database (psql", ($params->{port} == 5432 ? "" : " port $params->{port}"), "): ", join('; ', @out), "\n" if @out;
 


### PR DESCRIPTION
Since PG 15, the `public` schema has become read-only by default. This change grants the database user all permssions on this schema.

Given our usage pattern, generally a single user per database, this should be fine; the alternative would be to change the "default" schema to one named for the DB user in each database.

See: https://github.com/mysociety/sysadmin/issues/2004