### PR TITLE
[deploy-logger] Add posting to deploys channel.

### DIFF
--- a/bin/deploy-logger
+++ b/bin/deploy-logger
@@ -16,5 +16,7 @@ logger -p local6.notice -t mysociety_deploylogger -- "${WHO} ${@}"
 if [[ ! "$@" =~ "Deployed vhost" || ! "$@" =~ "test.mysociety.org" ]]
 then
   SLACK=`cat /etc/mysociety/slack.webhook`
-  curl --silent -X POST --data-urlencode 'payload={"channel": "#activity", "username": "DeployBot", "text": "'"[$HOST] $WHO $@"'", "icon_emoji": ":ms:"}' $SLACK >/dev/null
+  for channel in activity deploys; do
+      curl --silent -X POST --data-urlencode 'payload={"channel": "#'$channel'", "username": "DeployBot", "text": "'"[$HOST] $WHO $@"'", "icon_emoji": ":ms:"}' $SLACK >/dev/null
+  done
 fi


### PR DESCRIPTION
Was asked recently how to tell when something was deployed. Activity seemed pointless to point them at, but a channel that only had the deploys in seemed like it might be useful (also could be looked at when there's a brief false alert due to a deploy in #alerts, quicker than checking server deploy log).