### PR TITLE
[deploy-logger] Add threaded posting of deploys.

### DIFF
--- a/bin/deploy-dns
+++ b/bin/deploy-dns
@@ -137,12 +137,14 @@ try {
     my $help = 0;
     my $check_only = 0;
     my $no_check_existing = 0;
+    my $thread_id;
     if (!GetOptions(
             'help' =>           \$help,
             'verbose' =>        \$be_verbose,
             'quiet' =>          \$be_quiet,
             'check-only' =>     \$check_only,
             'no-check-existing' =>  \$no_check_existing,
+            'thread:s' => \$thread_id,
         )) {
         throw Oops("bad options; try --help for help");
     }
@@ -284,7 +286,7 @@ EOF
 
 
     # and before that's all banged out, log
-    shell('/data/mysociety/bin/deploy-logger', 'Deployed DNS')
+    shell('/data/mysociety/bin/deploy-logger', 'Deployed DNS', $thread_id)
         unless $be_quiet;
 done:
     $ret = 0;

--- a/bin/deploy-email
+++ b/bin/deploy-email
@@ -137,10 +137,12 @@ my $file_gid;
 try {
     my $help = 0;
     my $check_only = 0;
+    my $thread_id;
     if (!GetOptions(
             'help' =>           \$help,
             'verbose' =>        \$be_verbose,
             'quiet' =>          \$be_quiet,
+            'thread' => \$thread_id,
             'check-only' =>     \$check_only
         )) {
         throw Oops("bad options; try --help for help");
@@ -286,7 +288,7 @@ try {
     verbose("all done");
 
     # in which case, inform or log
-    shell('/data/mysociety/bin/deploy-logger', 'Deployed Email Config')
+    shell('/data/mysociety/bin/deploy-logger', 'Deployed Email Config', $thread_id)
         unless $be_quiet;
 
 done:

--- a/bin/deploy-logger
+++ b/bin/deploy-logger
@@ -3,20 +3,28 @@
 # deploy-logger:
 # Call to log whenever a deploy action happens.
 #
-# Arguments are the message to log, as in echo(1).
-#
+# Argument is the message to log, as in echo(1), plus an optional Slack thread ID.
 
 HOST=$(hostname)
 WHO=$(logname)
 
+MESSAGE="$1"
+THREAD="$2"
+
 # Send information to syslog.
-logger -p local6.notice -t mysociety_deploylogger -- "${WHO} ${@}"
+logger -p local6.notice -t mysociety_deploylogger -- "${WHO} ${MESSAGE}"
 
 # Post notice to Slack about log entry.
-if [[ ! "$@" =~ "Deployed vhost" || ! "$@" =~ "test.mysociety.org" ]]
-then
-  SLACK=`cat /etc/mysociety/slack.webhook`
-  for channel in activity deploys; do
-      curl --silent -X POST --data-urlencode 'payload={"channel": "#'$channel'", "username": "DeployBot", "text": "'"[$HOST] $WHO $@"'", "icon_emoji": ":ms:"}' $SLACK >/dev/null
-  done
+SLACK=`cat /etc/mysociety/slack.deploy.token`
+if [[ "$THREAD" ]]; then
+    TEXT="[$HOST] $MESSAGE"
+    curl --silent -d "token=$SLACK" -d "channel=deploys" --data-urlencode "text=$TEXT" -d "thread_ts=$THREAD" https://slack.com/api/chat.postMessage >/dev/null
+elif [[ "$@" =~ "on all servers" ]]; then
+    # We need to extract the thread ID for passing to subcommands
+    TEXT="$WHO $MESSAGE"
+    curl --silent -d "token=$SLACK" -d "channel=deploys" --data-urlencode "text=$TEXT" https://slack.com/api/chat.postMessage | jq .ts
+else
+    TEXT="[$HOST] $WHO $MESSAGE"
+    curl --silent -d "token=$SLACK" -d "channel=deploys" --data-urlencode "text=$TEXT" https://slack.com/api/chat.postMessage >/dev/null
 fi
+curl --silent -d "token=$SLACK" -d "channel=activity" --data-urlencode "text=$TEXT" https://slack.com/api/chat.postMessage >/dev/null

--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -20,6 +20,7 @@ use mySociety::Deploy;
 use Cwd;
 use DBI;
 use Errno;
+use Getopt::Long;
 use Time::Piece;
 use File::Path qw(make_path);
 use File::Copy;
@@ -42,18 +43,19 @@ mySociety::Deploy::read_conf($servers_dir);
 # Check command line parameters, look up in config file
 die "Specify virtual host name as first parameter, deploy/stop/update/start/remove/servers as second parameter" if scalar(@ARGV) < 2;
 
+my $flush;
+my $force;
+my $thread_id;
+GetOptions(
+    flush => \$flush,
+    force => \$force,
+    'thread:s' => \$thread_id,
+);
+
 my $vhost = shift @ARGV;
 
 my $action = shift @ARGV;
 die "Specify 'deploy', 'stop', 'update', 'start', 'servers', 'balancers' or 'remove' as second parameter" if $action ne "deploy" && $action ne "stop" && $action ne "update" && $action ne "start" && $action ne 'remove' && $action ne 'servers' && $action ne 'balancers';
-
-my $flush = 0;
-my $force = 0;
-
-foreach my $other_arg (@ARGV) {
-    $flush = 1 if $other_arg eq '--flush';
-    $force = 1 if $other_arg eq '--force';
-}
 
 my $hostname = `hostname`;
 chomp($hostname);
@@ -1095,7 +1097,7 @@ sub upgrade_db_password {
 
 sub deploy_logger {
     my $message = shift;
-    shell("/data/mysociety/bin/deploy-logger", $message);
+    shell("/data/mysociety/bin/deploy-logger", $message, $thread_id);
 }
 
 sub make_dir {

--- a/bin/mysociety
+++ b/bin/mysociety
@@ -140,7 +140,7 @@ case $COMMAND in
             shift || die "specify a vhost"
             # Deal with non-sensical commands combined with --all
             if [ "$COMMAND" == "servers" ] || [  "$COMMAND" == "balancers" ]; then die "Using ${COMMAND} with --all makes no sense."; fi
-            /data/mysociety/bin/deploy-logger "Performing ${COMMAND} for ${VHOST} on all servers"
+            THREAD_ID=$(/data/mysociety/bin/deploy-logger "Performing ${COMMAND} for ${VHOST} on all servers")
             if [ "$COMMAND" == "deploy" ]; then COMMAND=""; fi
             BALANCERS=$(mysociety vhost balancers "$VHOST")
             SERVERS=$(mysociety vhost servers "$VHOST")
@@ -172,7 +172,7 @@ case $COMMAND in
                     sleep 5
                 fi
                 echo -e "\033[34m[deploy] Performing ${COMMAND:-deploy} for ${VHOST} on ${s}...\033[0m"
-                ssh -t "$s" sudo mysociety vhost "$COMMAND" "$VHOST" "$@"
+                ssh -t "$s" sudo mysociety vhost "$COMMAND" "$VHOST" "$@" --thread $THREAD_ID
                 if [ "$COMMAND" != "stop" ] && [ "$COMMAND" != "remove" ]; then
                     if [ -n "$BALANCERS" ] && [ "$DO_VARNISH" == "yes" ]; then
                         # This should provide a bit of time for process manager to start, or at least have the
@@ -245,10 +245,10 @@ case $COMMAND in
 
     dns)
         if [ "$1" = "--all" ] ; then
-            /data/mysociety/bin/deploy-logger "Deploying DNS on all servers"
+            THREAD_ID=$(/data/mysociety/bin/deploy-logger "Deploying DNS on all servers")
             for srv in $(puppet query 'nodes [certname] { facts { name = "is_nameserver" and value = true } }' | jq -r .[].certname); do
                 echo " -- on ${srv}..."
-                ssh $srv "/data/mysociety/bin/mysociety dns --quiet" || echo " -- ...failed"
+                ssh $srv "/data/mysociety/bin/mysociety dns --quiet --thread $THREAD_ID" || echo " -- ...failed"
             done
         else
             exec /data/mysociety/bin/deploy-dns "$@"
@@ -257,10 +257,10 @@ case $COMMAND in
 
     email)
         if [ "$1" = "--all" ] ; then
-            /data/mysociety/bin/deploy-logger "Deploying email on all servers"
+            THREAD_ID=$(/data/mysociety/bin/deploy-logger "Deploying email on all servers")
             for srv in $(puppet query 'nodes [certname] { facts { name = "is_mailserver" and value = true } }' | jq -r .[].certname); do
                 echo " -- on ${srv}..."
-                ssh $srv "/data/mysociety/bin/mysociety email --quiet" || echo " -- ...failed"
+                ssh $srv "/data/mysociety/bin/mysociety email --quiet --thread $THREAD_ID" || echo " -- ...failed"
             done
         else
             exec /data/mysociety/bin/deploy-email "$@"


### PR DESCRIPTION
See deploy-test channel for example of what it should hopefully do.
deploy-logger will print a thread ID if given an "on all servers" log entry, which mysociety will capture and send to deploy-dns/deploy-email/deploy-vhost, which will in turn pass it on to deploy-logger to then log using that thread ID, meaning per-server log entries should be threaded under the "on all servers" entry.
Will need to add an /etc/mysociety/slack.deploy.token containing the Slack "Deploy bot" app bot token. (Couldn't use incoming webhook as that doesn't give you any message information.)