### PR TITLE
Improve Exim forward pipe generation

### DIFF
--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -1097,6 +1097,15 @@ sub start_site {
                         make_dot_forward($email_user, $script, $suffix);
                     }
                 }
+
+            } elsif (ref($email_conf) eq 'ARRAY') {
+                foreach my $entry (@$email_conf) {
+                    die "Email entry for $email_user is missing 'script' key" unless defined $entry->{script};
+
+                    # Pass wrapper explicitly (even if undef) to suppress ruby_version inference in make_dot_forward
+                    make_dot_forward($email_user, $entry->{script}, $entry->{suffix} || undef, $entry->{wrapper} || undef);
+                }
+
             } else {
                 make_dot_forward($email_user, $email_conf);
             }

--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -943,11 +943,13 @@ sub set_or_clear_ruby_version {
     copy($rbenv_profile, "/home/$conf->{'user'}/.profile.rbenv");
     shell("chown", "$conf->{user_uid}:$conf->{user_gid}", "/home/$conf->{'user'}/.profile.rbenv");
 
-    # add a wrapper script to allow the user's .forward files to operate with the right ruby version
+    # add a wrapper scripts to allow the user's .forward files to operate with the right ruby version
     # The logic in the mugly template checks for rbenv_global.
-    mugly("$servers_dir/vhosts/run-with-rbenv-path.ugly", "/home/$conf->{'user'}/run-with-rbenv-path");
-    shell("chown", "$conf->{user_uid}:$conf->{user_gid}", "/home/$conf->{'user'}/run-with-rbenv-path");
-    chmod 0755, "/home/$conf->{'user'}/run-with-rbenv-path";
+    foreach my $file ("run-with-rbenv-path", "run-with-rbenv-path-exec") {
+        mugly("$servers_dir/vhosts/$file.ugly", "/home/$conf->{'user'}/$file");
+        shell("chown", "$conf->{user_uid}:$conf->{user_gid}", "/home/$conf->{'user'}/$file");
+        chmod 0755, "/home/$conf->{'user'}/$file";
+    }
 
   } else {
 
@@ -969,6 +971,7 @@ sub resolve_wrapper {
 
     my %named_wrappers = (
         rbenv => "/home/${email_user}/run-with-rbenv-path",
+        rbenv_exec => "/home/${email_user}/run-with-rbenv-path-exec",
     );
 
     return $named_wrappers{$wrapper} // $wrapper;

--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -970,11 +970,11 @@ sub resolve_wrapper {
     my ($email_user, $wrapper) = @_;
 
     my %named_wrappers = (
-        rbenv => "/home/${email_user}/run-with-rbenv-path",
-        rbenv_exec => "/home/${email_user}/run-with-rbenv-path-exec",
+        rbenv => { bin => "/home/${email_user}/run-with-rbenv-path", },
+        rbenv_exec => { bin => "/home/${email_user}/run-with-rbenv-path-exec", chdir => 1 },
     );
 
-    return $named_wrappers{$wrapper} // $wrapper;
+    return $named_wrappers{$wrapper} // { bin => $wrapper };
 }
 
 sub make_dot_forward {
@@ -991,8 +991,13 @@ sub make_dot_forward {
     }
 
     if (defined $wrapper) {
-        my $wrapper_bin = resolve_wrapper($email_user, $wrapper);
-        $script = "$wrapper_bin $vhost_dir/$vcspath/$script";
+        my $w = resolve_wrapper($email_user, $wrapper);
+
+        if ($w->{chdir}) {
+            $script = "/bin/sh -c 'cd $vhost_dir/$vcspath && $w->{bin} $script'";
+        } else {
+            $script = "$w->{bin} $vhost_dir/$vcspath/$script";
+        }
     }
 
     # Create new version.

--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -962,8 +962,20 @@ sub set_or_clear_ruby_version {
   }
 }
 
+# Resolve a named wrapper (e.g. "rbenv") to the actual executable path,
+# or treat an unrecognised value as a literal path.
+sub resolve_wrapper {
+    my ($email_user, $wrapper) = @_;
+
+    my %named_wrappers = (
+        rbenv => "/home/${email_user}/run-with-rbenv-path",
+    );
+
+    return $named_wrappers{$wrapper} // $wrapper;
+}
+
 sub make_dot_forward {
-    my ($email_user, $script, $suffix) = @_;
+    my ($email_user, $script, $suffix, $wrapper) = @_;
     my $forward_file_name = defined($suffix) ? ".forward-$suffix" : ".forward";
 
     # remove any backup files created by the disable-email script.
@@ -971,13 +983,17 @@ sub make_dot_forward {
         unlink "/home/${email_user}/${forward_file_name}.bak";
     }
 
-    # Create new version.
-    if ($conf->{ruby_version}){
-        shell("su", "-", $email_user, "-c echo \"|/home/$conf->{'user'}/run-with-rbenv-path $vhost_dir/$vcspath/$script\" >~$email_user/$forward_file_name");
-    } else {
-        shell("su", "-", $email_user, "-c echo \"|$vhost_dir/$vcspath/$script\" >~$email_user/$forward_file_name");
+    if (scalar @_ < 4) {
+        $wrapper = 'rbenv' if $conf->{ruby_version};
     }
 
+    if (defined $wrapper) {
+        my $wrapper_bin = resolve_wrapper($email_user, $wrapper);
+        $script = "$wrapper_bin $vhost_dir/$vcspath/$script";
+    }
+
+    # Create new version.
+    shell("su", "-", $email_user, "-c echo \"|$script\" >~$email_user/$forward_file_name");
 }
 
 sub install_or_remove_crontab {

--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -1088,9 +1088,9 @@ sub start_site {
     # Make .forward files
     if ($conf->{'email'}) {
         foreach my $email_user (keys %{$conf->{'email'}}) {
-            my $email_pipeto = $conf->{'email'}->{$email_user};
-            if (ref($email_pipeto) eq "HASH") {
-                while (my ($suffix, $script) = each(%$email_pipeto)) {
+            my $email_conf = $conf->{'email'}->{$email_user};
+            if (ref($email_conf) eq "HASH") {
+                while (my ($suffix, $script) = each(%$email_conf)) {
                     if ($suffix eq '') {
                         make_dot_forward($email_user, $script);
                     } else {
@@ -1098,7 +1098,7 @@ sub start_site {
                     }
                 }
             } else {
-                make_dot_forward($email_user, $email_pipeto);
+                make_dot_forward($email_user, $email_conf);
             }
         }
     }


### PR DESCRIPTION
Allow JSON to be more explicit instead of automatically prefixing Exim forward pipes with the `run-with-rbenv-path` wrapper.

New format would look like:
```
{
  "email": {
    "email-user": [
      { "script": "path/to/default/script", "suffix": "" },
      { "script": "path/to/suffix/script",  "suffix": "suffix" },
      { "script": "path/to/ruby/script",    "suffix": "ruby", "wrapper": "rbenv" }
    ]
  }
}
```

This will allow us to set the script to `bin/rails actionmailbox:...`, using the new "rbenv_exec" wrapper. The old doesn't allow this as it calls `source` instead of `exec`.