### PR TITLE
[deploy-vhost] Explictly set permissions on .forward files

### DIFF
--- a/bin/deploy-vhost
+++ b/bin/deploy-vhost
@@ -1002,6 +1002,9 @@ sub make_dot_forward {
 
     # Create new version.
     shell("su", "-", $email_user, "-c echo \"|$script\" >~$email_user/$forward_file_name");
+
+    # Ensure permissions are correct: writeable only by the user, regardless of umask.
+    chmod 0644, "~${email_user}/${forward_file_name}";
 }
 
 sub install_or_remove_crontab {


### PR DESCRIPTION
These must be writeable only by the user. Currently we rely on the umask to govern this, which changes its default in Debian Trixie for users who have a private group rendering these files group writeable in cases like this which will prevent the MTA from using the file.

See: https://wiki.debian.org/Permissions#Setting_default_umask